### PR TITLE
chore(testcontainers): migrated to testcontainers [PW-206]

### DIFF
--- a/.github/workflows/api-cd.yml
+++ b/.github/workflows/api-cd.yml
@@ -47,15 +47,10 @@ jobs:
           echo "security.cors.allowed-origins=*" >> ./api/src/test/resources/application-it.properties
           echo "security.jwt.secret-key=${{ secrets.API_SECURITY_JWT_SECRET_KEY }}" >> ./api/src/test/resources/application-it.properties
           echo "spring.application.name=personal-website-api" >> ./api/src/test/resources/application-it.properties
-          echo "spring.datasource.url=${{ secrets.API_SPRING_TEST_DATASOURCE_URL }}" >> ./api/src/test/resources/application-it.properties
-          echo "spring.datasource.username=${{ secrets.API_SPRING_DATASOURCE_USERNAME }}" >> ./api/src/test/resources/application-it.properties
-          echo "spring.datasource.password=${{ secrets.API_SPRING_DATASOURCE_PASSWORD }}" >> ./api/src/test/resources/application-it.properties
           echo "spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver" >> ./api/src/test/resources/application-it.properties
-          echo "spring.jpa.hibernate.ddl-auto=create-drop" >> ./api/src/test/resources/application-it.properties
+          echo "spring.jpa.hibernate.ddl-auto=create" >> ./api/src/test/resources/application-it.properties
           echo "spring.cache.type=redis" >> ./api/src/test/resources/application-it.properties
           echo "spring.cache.redis.time-to-live=900000" >> ./api/src/test/resources/application-it.properties
-          echo "spring.data.redis.host=${{ secrets.API_TEST_SPRING_CACHE_HOST }}" >> ./api/src/test/resources/application-it.properties
-          echo "spring.data.redis.port=6379" >> ./api/src/test/resources/application-it.properties
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3

--- a/.github/workflows/api-cd.yml
+++ b/.github/workflows/api-cd.yml
@@ -16,6 +16,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+      - uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: 'maven'
 
       - name: Create application.properties for Integration Tests
         run: |
@@ -61,6 +66,7 @@ jobs:
       - name: Build, Test, Deploy API
         working-directory: ./api
         run: |
+          mvn -ntp clean verify
           docker build . -t michaelyi/personal-website-api:${{ env.VERSION }}
           docker push michaelyi/personal-website-api:${{ env.VERSION }}
 

--- a/.github/workflows/api-ci.yml
+++ b/.github/workflows/api-ci.yml
@@ -12,6 +12,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+      - uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: 'maven'
 
       - name: Create application.properties for Integration Tests
         run: |
@@ -50,4 +55,4 @@ jobs:
 
       - name: Build & Test API
         working-directory: ./api
-        run: docker build .
+        run: mvn -ntp clean verify 

--- a/.github/workflows/api-ci.yml
+++ b/.github/workflows/api-ci.yml
@@ -43,15 +43,10 @@ jobs:
           echo "security.cors.allowed-origins=*" >> ./api/src/test/resources/application-it.properties
           echo "security.jwt.secret-key=${{ secrets.API_SECURITY_JWT_SECRET_KEY }}" >> ./api/src/test/resources/application-it.properties
           echo "spring.application.name=personal-website-api" >> ./api/src/test/resources/application-it.properties
-          echo "spring.datasource.url=${{ secrets.API_SPRING_TEST_DATASOURCE_URL }}" >> ./api/src/test/resources/application-it.properties
-          echo "spring.datasource.username=${{ secrets.API_SPRING_DATASOURCE_USERNAME }}" >> ./api/src/test/resources/application-it.properties
-          echo "spring.datasource.password=${{ secrets.API_SPRING_DATASOURCE_PASSWORD }}" >> ./api/src/test/resources/application-it.properties
           echo "spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver" >> ./api/src/test/resources/application-it.properties
-          echo "spring.jpa.hibernate.ddl-auto=create-drop" >> ./api/src/test/resources/application-it.properties
+          echo "spring.jpa.hibernate.ddl-auto=create" >> ./api/src/test/resources/application-it.properties
           echo "spring.cache.type=redis" >> ./api/src/test/resources/application-it.properties
           echo "spring.cache.redis.time-to-live=900000" >> ./api/src/test/resources/application-it.properties
-          echo "spring.data.redis.host=${{ secrets.API_TEST_SPRING_CACHE_HOST }}" >> ./api/src/test/resources/application-it.properties
-          echo "spring.data.redis.port=6379" >> ./api/src/test/resources/application-it.properties
 
       - name: Build & Test API
         working-directory: ./api

--- a/README.md
+++ b/README.md
@@ -16,15 +16,17 @@ This repository contains the source code to my personal website and film blog. I
 ## Tech Stack
 
 - [Java](https://www.java.com/en/)
-- [JavaScript](https://www.javascript.com/)
 - [Spring Boot](https://spring.io/projects/spring-boot)
 - [MySQL](https://www.mysql.com/)
 - [Redis](https://redis.io/)
-- [React](https://react.dev/)
 - [AWS EC2, S3](https://aws.amazon.com/)
 - [Docker](https://www.docker.com/)
-- [Nginx](https://www.nginx.com/)
 - [JUnit](https://junit.org/junit5/)
+- [Mockito](https://site.mockito.org/)
+- [Testcontainers](https://testcontainers.com/)
+- [Nginx](https://www.nginx.com/)
+- [JavaScript](https://www.javascript.com/)
+- [React](https://react.dev/)
 - [TailwindCSS](https://tailwindcss.com/)
 
 ## Screenshots

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,7 +1,3 @@
-FROM maven:3.8.3-openjdk-17 AS build  
-COPY . /usr/src/app
-RUN mvn -f /usr/src/app/pom.xml -ntp clean verify 
-
 FROM openjdk:17
-COPY --from=build /usr/src/app/target/*.jar app.jar  
+COPY --from=build target/*.jar app.jar  
 ENTRYPOINT ["java","-jar","/app.jar"]

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -103,6 +103,18 @@
             <artifactId>h2</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>mysql</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/api/src/test/java/com/michaelhyi/integration/AuthIT.java
+++ b/api/src/test/java/com/michaelhyi/integration/AuthIT.java
@@ -41,9 +41,10 @@ import io.jsonwebtoken.security.Keys;
 @SpringBootTest(webEnvironment = RANDOM_PORT)
 @TestPropertySource("classpath:application-it.properties")
 class AuthIT {
+    private static final int REDIS_PORT = 6379;
     static MySQLContainer<?> mysql = new MySQLContainer<>("mysql:8.0.36");
     static GenericContainer<?> redis = new GenericContainer<>("redis:6.2.14")
-                                            .withExposedPorts(6379);
+                                            .withExposedPorts(REDIS_PORT);
 
     @DynamicPropertySource
     static void configureProperties(DynamicPropertyRegistry registry) {
@@ -51,7 +52,7 @@ class AuthIT {
         registry.add("spring.datasource.username", mysql::getUsername);
         registry.add("spring.datasource.password", mysql::getPassword);
         registry.add("spring.data.redis.host", redis::getHost);
-        registry.add("spring.data.redis.port", () -> String.valueOf(6379)); 
+        registry.add("spring.data.redis.port", () -> String.valueOf(redis.getMappedPort(REDIS_PORT))); 
     }
 
     @Autowired

--- a/api/src/test/java/com/michaelhyi/integration/AuthIT.java
+++ b/api/src/test/java/com/michaelhyi/integration/AuthIT.java
@@ -2,13 +2,16 @@ package com.michaelhyi.integration;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -17,8 +20,12 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cache.CacheManager;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.MySQLContainer;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
 import com.michaelhyi.dao.UserRepository;
@@ -30,10 +37,23 @@ import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
 
-@SpringBootTest
 @AutoConfigureMockMvc
+@SpringBootTest(webEnvironment = RANDOM_PORT)
 @TestPropertySource("classpath:application-it.properties")
 class AuthIT {
+    static MySQLContainer<?> mysql = new MySQLContainer<>("mysql:8.0.36");
+    static GenericContainer<?> redis = new GenericContainer<>("redis:6.2.14")
+                                            .withExposedPorts(6379);
+
+    @DynamicPropertySource
+    static void configureProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", mysql::getJdbcUrl);
+        registry.add("spring.datasource.username", mysql::getUsername);
+        registry.add("spring.datasource.password", mysql::getPassword);
+        registry.add("spring.data.redis.host", redis::getHost);
+        registry.add("spring.data.redis.port", () -> String.valueOf(6379)); 
+    }
+
     @Autowired
     private MockMvc mvc;
 
@@ -50,6 +70,12 @@ class AuthIT {
     private ObjectMapper mapper;
     private ObjectWriter writer;
 
+    @BeforeAll
+    static void beforeAll() {
+        mysql.start();
+        redis.start();
+    }
+
     @BeforeEach
     void setUp() {
         repository.deleteAll();
@@ -61,7 +87,13 @@ class AuthIT {
         cacheManager.getCacheNames()
                     .parallelStream()
                     .forEach(n -> cacheManager.getCache(n).clear());
-    } 
+    }
+
+    @AfterAll
+    static void afterAll() {
+        mysql.stop();
+        redis.stop();
+    }
 
     @Test
     void login() throws Exception {

--- a/api/src/test/java/com/michaelhyi/integration/PostIT.java
+++ b/api/src/test/java/com/michaelhyi/integration/PostIT.java
@@ -41,9 +41,10 @@ import com.michaelhyi.service.S3Service;
 @SpringBootTest(webEnvironment = RANDOM_PORT)
 @TestPropertySource("classpath:application-it.properties")
 class PostIT {
+    private static final int REDIS_PORT = 6379;
     static MySQLContainer<?> mysql = new MySQLContainer<>("mysql:8.0.36");
     static GenericContainer<?> redis = new GenericContainer<>("redis:6.2.14")
-                                            .withExposedPorts(6379);
+                                            .withExposedPorts(REDIS_PORT);
 
     @DynamicPropertySource
     static void configureProperties(DynamicPropertyRegistry registry) {
@@ -51,7 +52,7 @@ class PostIT {
         registry.add("spring.datasource.username", mysql::getUsername);
         registry.add("spring.datasource.password", mysql::getPassword);
         registry.add("spring.data.redis.host", redis::getHost);
-        registry.add("spring.data.redis.port", () -> String.valueOf(6379)); 
+        registry.add("spring.data.redis.port", () -> String.valueOf(redis.getMappedPort(REDIS_PORT))); 
     }
 
     @Autowired


### PR DESCRIPTION
## Summary

Utilizing Testcontainers instead of cloud-hosted database servers. Making integration testing easier and saves costs.

## Changelog

- Removed test database servers on AWS EC2.
- Installed Testcontainers and migrated integration tests to utilize them.
- Updated README accordingly.
- Moved Maven builds + tests out of docker container, running builds directly through CI/CD.

## Test Plan

- Ran integration tests to ensure 100% test coverage.