### PR TITLE
fix(ci/cd): removed from build stage in Dockerfile for api

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,3 +1,3 @@
 FROM openjdk:17
-COPY --from=build target/*.jar app.jar  
+COPY target/*.jar app.jar  
 ENTRYPOINT ["java","-jar","/app.jar"]


### PR DESCRIPTION
## Summary

Forgot to remove --from=build step in Dockerfile, thus failing in CD.

## Changelog

- Removed --from=build from Dockerfile

## Test Plan

N/A