### PR TITLE
refactor(tests): removed h2 database and unnecessary properties

### DIFF
--- a/.github/workflows/api-cd.yml
+++ b/.github/workflows/api-cd.yml
@@ -44,6 +44,7 @@ jobs:
 
       - name: Create application-it.properties
         run: |
+          mkdir ./api/src/test/resources
           touch ./api/src/test/resources/application-it.properties
           echo "auth.whitelisted-emails=test@mail.com" >> ./api/src/test/resources/application-it.properties
           echo "aws.access-key=${{ secrets.API_AWS_ACCESS_KEY }}" >> ./api/src/test/resources/application-it.properties

--- a/.github/workflows/api-ci.yml
+++ b/.github/workflows/api-ci.yml
@@ -40,6 +40,7 @@ jobs:
 
       - name: Create application-it.properties
         run: |
+          mkdir ./api/src/test/resources
           touch ./api/src/test/resources/application-it.properties
           echo "auth.whitelisted-emails=test@mail.com" >> ./api/src/test/resources/application-it.properties
           echo "aws.access-key=${{ secrets.API_AWS_ACCESS_KEY }}" >> ./api/src/test/resources/application-it.properties

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -99,12 +99,6 @@
         </dependency>
 
         <dependency>
-            <groupId>com.h2database</groupId>
-            <artifactId>h2</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>

--- a/api/src/test/java/com/michaelhyi/unit/PostServiceTest.java
+++ b/api/src/test/java/com/michaelhyi/unit/PostServiceTest.java
@@ -42,7 +42,7 @@ class PostServiceTest {
     void setUp() {
         underTest = new PostService(repository, s3Service);
     }
-    
+
     @Test
     void willThrowPostConstructorWhenBadRequest() {
         assertThrows(IllegalArgumentException.class, () -> new Post(new PostRequest(null)));

--- a/api/src/test/resources/application.properties
+++ b/api/src/test/resources/application.properties
@@ -1,7 +1,0 @@
-auth.whitelisted-emails=test@mail.com
-
-spring.datasource.url=jdbc:h2://mem:db;DB_CLOSE_DELAY=-1
-spring.datasource.username=sa
-spring.datasource.password=sa
-spring.datasource.driver-class-name=org.h2.Driver
-spring.jpa.hibernate.ddl-auto=create-drop


### PR DESCRIPTION
## Summary

Removed H2 DB and properties files for unit testing, as they are redundant.

## Changelog

- Removed H2 DB from properties files.
- Updated CI/CD pipeline to create a directory for adding integration testing properties.

## Test Plan

Ran Spring Boot testing suite to ensure 100% coverage.