### PR TITLE
refactor(validate-token): moved jwt token to bearer token to validate [PW-216]

### DIFF
--- a/admin/src/components/AuthorizedRoute.jsx
+++ b/admin/src/components/AuthorizedRoute.jsx
@@ -9,18 +9,12 @@ export default function AuthorizedRoute({ children }) {
 
     useEffect(() => {
         (async () => {
-            const token = localStorage.getItem("token");
-
-            if (!token) {
+            try {
+                await validateToken();
+                setLoading(false);
+            } catch {
+                localStorage.removeItem("token");
                 navigate("/");
-            } else {
-                try {
-                    await validateToken(token);
-                    setLoading(false);
-                } catch {
-                    localStorage.removeItem("token");
-                    navigate("/");
-                }
             }
         })();
     }, [navigate]);

--- a/admin/src/components/UnauthorizedRoute.jsx
+++ b/admin/src/components/UnauthorizedRoute.jsx
@@ -9,18 +9,12 @@ export default function UnauthorizedRoute({ children }) {
 
     useEffect(() => {
         (async () => {
-            const token = localStorage.getItem("token");
-
-            if (!token) {
+            try {
+                await validateToken();
+                navigate("/blog");
+            } catch {
+                localStorage.removeItem("token");
                 setLoading(false);
-            } else {
-                try {
-                    await validateToken(token);
-                    navigate("/blog");
-                } catch {
-                    localStorage.removeItem("token");
-                    setLoading(false);
-                }
             }
         })();
     }, [navigate]);

--- a/admin/src/services/auth.js
+++ b/admin/src/services/auth.js
@@ -1,4 +1,5 @@
 import axios from "axios";
+import authConfig from "./authConfig";
 
 async function extractUsernameFromGoogleToken(token) {
     const { data } = await axios(
@@ -22,8 +23,9 @@ export async function login(googleToken) {
     localStorage.setItem("token", jwt);
 }
 
-export async function validateToken(token) {
+export async function validateToken() {
     await axios(
-        `${process.env.REACT_APP_API_URL}/v1/auth/validate-token/${token}`,
+        `${process.env.REACT_APP_API_URL}/v1/auth/validate-token`,
+        authConfig(),
     );
 }

--- a/admin/src/services/authConfig.js
+++ b/admin/src/services/authConfig.js
@@ -1,0 +1,7 @@
+export default function authConfig() {
+    return {
+        headers: {
+            Authorization: `Bearer ${localStorage.getItem("token")}`,
+        },
+    };
+}

--- a/admin/src/services/post.js
+++ b/admin/src/services/post.js
@@ -1,12 +1,5 @@
 import axios from "axios";
-
-function authConfig() {
-    return {
-        headers: {
-            Authorization: `Bearer ${localStorage.getItem("token")}`,
-        },
-    };
-}
+import authConfig from "./authConfig";
 
 export async function createPost(text) {
     const { data } = await axios.post(

--- a/api/.gitignore
+++ b/api/.gitignore
@@ -1,3 +1,4 @@
+.idea/
 target/
 
 src/main/resources/application.properties

--- a/api/src/main/java/com/michaelhyi/config/ApplicationConfig.java
+++ b/api/src/main/java/com/michaelhyi/config/ApplicationConfig.java
@@ -1,7 +1,7 @@
 package com.michaelhyi.config;
 
-import java.util.List;
-
+import com.michaelhyi.dao.UserRepository;
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -12,9 +12,7 @@ import org.springframework.security.config.annotation.authentication.configurati
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 
-import com.michaelhyi.dao.UserRepository;
-
-import lombok.RequiredArgsConstructor;
+import java.util.List;
 
 @Configuration
 @RequiredArgsConstructor
@@ -42,7 +40,7 @@ public class ApplicationConfig {
     public UserDetailsService userDetailsService() {
         return username -> repository.findById(username)
                 .orElseThrow(() ->
-                    new UsernameNotFoundException("User not found.")
+                        new UsernameNotFoundException("User not found.")
                 );
     }
 

--- a/api/src/main/java/com/michaelhyi/config/CorsConfig.java
+++ b/api/src/main/java/com/michaelhyi/config/CorsConfig.java
@@ -1,14 +1,14 @@
 package com.michaelhyi.config;
 
-import java.util.Arrays;
-import java.util.List;
-
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.Arrays;
+import java.util.List;
 
 @Configuration
 public class CorsConfig {

--- a/api/src/main/java/com/michaelhyi/config/S3Config.java
+++ b/api/src/main/java/com/michaelhyi/config/S3Config.java
@@ -3,7 +3,6 @@ package com.michaelhyi.config;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
@@ -27,8 +26,8 @@ public class S3Config {
         return S3Client
                 .builder()
                 .credentialsProvider(
-                    StaticCredentialsProvider
-                        .create(credentials))
+                        StaticCredentialsProvider
+                                .create(credentials))
                 .region(Region.of(AWS_REGION))
                 .build();
     }

--- a/api/src/main/java/com/michaelhyi/config/SecurityConfig.java
+++ b/api/src/main/java/com/michaelhyi/config/SecurityConfig.java
@@ -1,5 +1,7 @@
 package com.michaelhyi.config;
 
+import com.michaelhyi.jwt.JwtAuthenticationFilter;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
@@ -13,8 +15,6 @@ import org.springframework.security.config.annotation.web.configurers.HeadersCon
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
-import com.michaelhyi.jwt.JwtAuthenticationFilter;
-import lombok.RequiredArgsConstructor;
 
 @Configuration
 @EnableWebSecurity
@@ -31,33 +31,33 @@ public class SecurityConfig {
     ) throws Exception {
         return http
                 .headers(headers -> headers
-                                        .cacheControl(HeadersConfigurer
-                                            .CacheControlConfig::disable)
-                                        .frameOptions(HeadersConfigurer
-                                            .FrameOptionsConfig::disable))
+                        .cacheControl(HeadersConfigurer
+                                .CacheControlConfig::disable)
+                        .frameOptions(HeadersConfigurer
+                                .FrameOptionsConfig::disable))
                 .csrf(AbstractHttpConfigurer::disable)
                 .cors(Customizer.withDefaults())
                 .authorizeHttpRequests(auth -> auth
-                                        .requestMatchers("/v1/auth/**")
-                                        .permitAll()
-                                        .requestMatchers(HttpMethod.POST)
-                                        .hasAnyRole(ADMIN)
-                                        .requestMatchers(HttpMethod.GET)
-                                        .permitAll()
-                                        .requestMatchers(HttpMethod.PUT)
-                                        .hasAnyRole(ADMIN)
-                                        .requestMatchers(HttpMethod.DELETE)
-                                        .hasAnyRole(ADMIN)
-                                        .anyRequest()
-                                        .authenticated())
+                        .requestMatchers("/v1/auth/**")
+                        .permitAll()
+                        .requestMatchers(HttpMethod.POST)
+                        .hasAnyRole(ADMIN)
+                        .requestMatchers(HttpMethod.GET)
+                        .permitAll()
+                        .requestMatchers(HttpMethod.PUT)
+                        .hasAnyRole(ADMIN)
+                        .requestMatchers(HttpMethod.DELETE)
+                        .hasAnyRole(ADMIN)
+                        .anyRequest()
+                        .authenticated())
                 .sessionManagement(sess -> sess
-                                            .sessionCreationPolicy(
-                                                SessionCreationPolicy.STATELESS
-                                            ))
+                        .sessionCreationPolicy(
+                                SessionCreationPolicy.STATELESS
+                        ))
                 .authenticationProvider(authenticationProvider)
                 .addFilterBefore(
-                    jwtAuthFilter,
-                    UsernamePasswordAuthenticationFilter.class)
+                        jwtAuthFilter,
+                        UsernamePasswordAuthenticationFilter.class)
                 .build();
     }
 }

--- a/api/src/main/java/com/michaelhyi/controller/AuthController.java
+++ b/api/src/main/java/com/michaelhyi/controller/AuthController.java
@@ -1,16 +1,15 @@
 package com.michaelhyi.controller;
 
-import org.springframework.cache.annotation.Cacheable;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
 import com.michaelhyi.dto.LoginRequest;
 import com.michaelhyi.service.AuthService;
-
 import lombok.AllArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @AllArgsConstructor
@@ -24,8 +23,9 @@ public class AuthController {
         return service.login(req.email());
     }
 
-    @GetMapping("validate-token/{token}")
-    public void validateToken(@PathVariable("token") String token) {
+    @GetMapping("validate-token")
+    public void validateToken(@RequestHeader("Authorization") String authHeader) {
+        String token = authHeader.substring(7);
         service.validateToken(token);
     }
 }

--- a/api/src/main/java/com/michaelhyi/controller/AuthController.java
+++ b/api/src/main/java/com/michaelhyi/controller/AuthController.java
@@ -24,7 +24,9 @@ public class AuthController {
     }
 
     @GetMapping("validate-token")
-    public void validateToken(@RequestHeader("Authorization") String authHeader) {
+    public void validateToken(
+            @RequestHeader("Authorization") String authHeader
+    ) {
         String token = authHeader.substring(7);
         service.validateToken(token);
     }

--- a/api/src/main/java/com/michaelhyi/controller/PostController.java
+++ b/api/src/main/java/com/michaelhyi/controller/PostController.java
@@ -1,6 +1,9 @@
 package com.michaelhyi.controller;
 
-import java.util.List;
+import com.michaelhyi.dto.PostRequest;
+import com.michaelhyi.entity.Post;
+import com.michaelhyi.service.PostService;
+import lombok.AllArgsConstructor;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.CachePut;
 import org.springframework.cache.annotation.Cacheable;
@@ -16,11 +19,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
-import com.michaelhyi.dto.PostRequest;
-import com.michaelhyi.entity.Post;
-import com.michaelhyi.service.PostService;
-
-import lombok.AllArgsConstructor;
+import java.util.List;
 
 @RestController
 @AllArgsConstructor
@@ -35,12 +34,12 @@ public class PostController {
     }
 
     @PostMapping(
-        value = "{id}/image",
-        consumes = MediaType.MULTIPART_FORM_DATA_VALUE
+            value = "{id}/image",
+            consumes = MediaType.MULTIPART_FORM_DATA_VALUE
     )
     public void createPostImage(
-        @PathVariable("id") String id,
-        @RequestParam("file") MultipartFile file
+            @PathVariable("id") String id,
+            @RequestParam("file") MultipartFile file
     ) {
         service.createPostImage(id, file);
     }
@@ -52,8 +51,8 @@ public class PostController {
     }
 
     @GetMapping(
-        value = "{id}/image",
-        produces = MediaType.IMAGE_JPEG_VALUE
+            value = "{id}/image",
+            produces = MediaType.IMAGE_JPEG_VALUE
     )
     @Cacheable(value = "readPostImage", key = "#id")
     public byte[] readPostImage(@PathVariable("id") String id) {
@@ -69,8 +68,8 @@ public class PostController {
     @PutMapping("{id}")
     @CachePut(cacheNames = {"readAllPosts", "readPost"}, key = "#id")
     public Post updatePost(
-        @PathVariable("id") String id,
-        @RequestBody PostRequest req
+            @PathVariable("id") String id,
+            @RequestBody PostRequest req
     ) {
         return service.updatePost(id, req);
     }

--- a/api/src/main/java/com/michaelhyi/dao/PostRepository.java
+++ b/api/src/main/java/com/michaelhyi/dao/PostRepository.java
@@ -1,10 +1,8 @@
 package com.michaelhyi.dao;
 
-import org.springframework.data.jpa.repository.JpaRepository;
-
 import com.michaelhyi.entity.Post;
-
 import jakarta.transaction.Transactional;
+import org.springframework.data.jpa.repository.JpaRepository;
 
 @Transactional
 public interface PostRepository extends JpaRepository<Post, String> {

--- a/api/src/main/java/com/michaelhyi/dao/UserRepository.java
+++ b/api/src/main/java/com/michaelhyi/dao/UserRepository.java
@@ -1,10 +1,8 @@
 package com.michaelhyi.dao;
 
-import org.springframework.data.jpa.repository.JpaRepository;
-
 import com.michaelhyi.entity.User;
-
 import jakarta.transaction.Transactional;
+import org.springframework.data.jpa.repository.JpaRepository;
 
 @Transactional
 public interface UserRepository extends JpaRepository<User, String> {

--- a/api/src/main/java/com/michaelhyi/dto/LoginRequest.java
+++ b/api/src/main/java/com/michaelhyi/dto/LoginRequest.java
@@ -1,6 +1,6 @@
 package com.michaelhyi.dto;
 
 public record LoginRequest(
-    String email
+        String email
 ) {
 }

--- a/api/src/main/java/com/michaelhyi/dto/PostRequest.java
+++ b/api/src/main/java/com/michaelhyi/dto/PostRequest.java
@@ -1,6 +1,6 @@
 package com.michaelhyi.dto;
 
 public record PostRequest(
-    String text
+        String text
 ) {
 }

--- a/api/src/main/java/com/michaelhyi/entity/Post.java
+++ b/api/src/main/java/com/michaelhyi/entity/Post.java
@@ -1,8 +1,5 @@
 package com.michaelhyi.entity;
 
-import java.io.Serializable;
-import java.util.Date;
-import org.hibernate.annotations.CreationTimestamp;
 import com.michaelhyi.dto.PostRequest;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -12,6 +9,10 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.io.Serializable;
+import java.util.Date;
 
 @Entity
 @Getter
@@ -22,8 +23,8 @@ public class Post implements Serializable {
     @Id
     @Setter(AccessLevel.NONE)
     @Column(
-        nullable = false,
-        unique = true
+            nullable = false,
+            unique = true
     )
     private String id;
 
@@ -34,8 +35,8 @@ public class Post implements Serializable {
 
     @Setter(AccessLevel.NONE)
     @Column(
-        nullable = false,
-        unique = true
+            nullable = false,
+            unique = true
     )
     private String title;
 
@@ -44,8 +45,8 @@ public class Post implements Serializable {
 
     public Post(PostRequest req) {
         if (req.text() == null
-            || req.text().isBlank()
-            || req.text().isEmpty()) {
+                || req.text().isBlank()
+                || req.text().isEmpty()) {
             throw new IllegalArgumentException("Fields cannot be blank.");
         }
 
@@ -68,27 +69,27 @@ public class Post implements Serializable {
         }
 
         boolean containsYear = newTitle.contains("(")
-                                && newTitle.contains(")")
-                                && newTitle.indexOf(")")
-                                    - newTitle.indexOf("(") == 5;
+                && newTitle.contains(")")
+                && newTitle.indexOf(")")
+                - newTitle.indexOf("(") == 5;
 
         if (!containsYear) {
             throw new IllegalArgumentException(
-                "Title must contain a year in parentheses.");
+                    "Title must contain a year in parentheses.");
         }
 
         if (newTitle.contains("(")
-            && !newTitle.substring(
-                    newTitle.indexOf("(") - 1,
-                    newTitle.indexOf("(")
-                ).equals(" ")) {
+                && !newTitle.substring(
+                newTitle.indexOf("(") - 1,
+                newTitle.indexOf("(")
+        ).equals(" ")) {
             throw new IllegalArgumentException(
-                "Year must be preceded by a space.");
+                    "Year must be preceded by a space.");
         }
 
         String newId = newTitle.toLowerCase()
-                                .replace(" ", "-")
-                                .replaceAll("[^a-z\\-]", "");
+                .replace(" ", "-")
+                .replaceAll("[^a-z\\-]", "");
 
         id = newId.charAt(newId.length() - 1) == '-'
                 ? newId.substring(0, newId.length() - 1) : newId;

--- a/api/src/main/java/com/michaelhyi/entity/User.java
+++ b/api/src/main/java/com/michaelhyi/entity/User.java
@@ -1,10 +1,5 @@
 package com.michaelhyi.entity;
 
-import java.util.Collection;
-import java.util.List;
-import org.springframework.security.core.GrantedAuthority;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
-import org.springframework.security.core.userdetails.UserDetails;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -13,6 +8,12 @@ import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.List;
 
 @Entity
 @Getter
@@ -22,9 +23,9 @@ import lombok.NoArgsConstructor;
 public class User implements UserDetails {
     @Id
     @Column(
-        nullable = false,
-        unique = true,
-        updatable = false
+            nullable = false,
+            unique = true,
+            updatable = false
     )
     private String email;
 

--- a/api/src/main/java/com/michaelhyi/exception/ErrorHandler.java
+++ b/api/src/main/java/com/michaelhyi/exception/ErrorHandler.java
@@ -9,48 +9,48 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 public class ErrorHandler {
     @ExceptionHandler(IllegalArgumentException.class)
     public ResponseEntity<String> handleException(
-        IllegalArgumentException e
+            IllegalArgumentException e
     ) {
         return new ResponseEntity<>(e.getMessage(), HttpStatus.BAD_REQUEST);
     }
 
     @ExceptionHandler(PostNotFoundException.class)
     public ResponseEntity<String> handleException(
-        PostNotFoundException e
+            PostNotFoundException e
     ) {
         return new ResponseEntity<>(e.getMessage(), HttpStatus.NOT_FOUND);
     }
 
     @ExceptionHandler(S3ServiceException.class)
     public ResponseEntity<String> handleException(
-        S3ServiceException e
+            S3ServiceException e
     ) {
         return new ResponseEntity<>(
-            e.getMessage(),
-            HttpStatus.INTERNAL_SERVER_ERROR
+                e.getMessage(),
+                HttpStatus.INTERNAL_SERVER_ERROR
         );
     }
 
     @ExceptionHandler(S3ObjectNotFoundException.class)
     public ResponseEntity<String> handleException(
-        S3ObjectNotFoundException e
+            S3ObjectNotFoundException e
     ) {
         return new ResponseEntity<>(
-            e.getMessage(),
-            HttpStatus.NOT_FOUND
+                e.getMessage(),
+                HttpStatus.NOT_FOUND
         );
     }
 
     @ExceptionHandler(UnauthorizedUserException.class)
     public ResponseEntity<String> handleException(
-        UnauthorizedUserException e
+            UnauthorizedUserException e
     ) {
         return new ResponseEntity<>(e.getMessage(), HttpStatus.UNAUTHORIZED);
     }
 
     @ExceptionHandler(UserNotFoundException.class)
     public ResponseEntity<String> handleException(
-        UserNotFoundException e
+            UserNotFoundException e
     ) {
         return new ResponseEntity<>(e.getMessage(), HttpStatus.NOT_FOUND);
     }

--- a/api/src/main/java/com/michaelhyi/jwt/JwtAuthenticationFilter.java
+++ b/api/src/main/java/com/michaelhyi/jwt/JwtAuthenticationFilter.java
@@ -1,7 +1,10 @@
 package com.michaelhyi.jwt;
 
-import java.io.IOException;
-
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.AllArgsConstructor;
 import org.springframework.lang.NonNull;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -10,11 +13,8 @@ import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
-import jakarta.servlet.FilterChain;
-import jakarta.servlet.ServletException;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
-import lombok.AllArgsConstructor;
+
+import java.io.IOException;
 
 @Component
 @AllArgsConstructor
@@ -24,9 +24,9 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     @Override
     protected void doFilterInternal(
-        @NonNull HttpServletRequest request,
-        @NonNull HttpServletResponse response,
-        @NonNull FilterChain filterChain
+            @NonNull HttpServletRequest request,
+            @NonNull HttpServletResponse response,
+            @NonNull FilterChain filterChain
     ) throws ServletException, IOException {
         if (request.getServletPath().contains("/v1/auth")) {
             filterChain.doFilter(request, response);

--- a/api/src/main/java/com/michaelhyi/jwt/JwtService.java
+++ b/api/src/main/java/com/michaelhyi/jwt/JwtService.java
@@ -1,14 +1,5 @@
 package com.michaelhyi.jwt;
 
-import java.security.Key;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.function.Function;
-
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.stereotype.Service;
 import com.michaelhyi.exception.UnauthorizedUserException;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.JwtException;
@@ -16,6 +7,15 @@ import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Service;
+
+import java.security.Key;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
 
 @Service
 public class JwtService {
@@ -24,9 +24,9 @@ public class JwtService {
     private static final long EXPIRATION = 6048000000L;
 
     private String buildToken(
-        Map<String, Object> extraClaims,
-        UserDetails userDetails,
-        long expiration
+            Map<String, Object> extraClaims,
+            UserDetails userDetails,
+            long expiration
     ) {
         return Jwts
                 .builder()
@@ -54,8 +54,8 @@ public class JwtService {
     }
 
     public <T> T extractClaim(
-        String token,
-        Function<Claims, T> claimsResolver
+            String token,
+            Function<Claims, T> claimsResolver
     ) {
         final Claims claims = extractAllClaims(token);
         return claimsResolver.apply(claims);
@@ -74,8 +74,8 @@ public class JwtService {
     }
 
     public String generateToken(
-        Map<String, Object> extraClaims,
-        UserDetails userDetails
+            Map<String, Object> extraClaims,
+            UserDetails userDetails
     ) {
         return buildToken(extraClaims, userDetails, EXPIRATION);
     }

--- a/api/src/main/java/com/michaelhyi/service/AuthService.java
+++ b/api/src/main/java/com/michaelhyi/service/AuthService.java
@@ -1,14 +1,15 @@
 package com.michaelhyi.service;
 
-import java.util.List;
-import java.util.Optional;
-import org.springframework.stereotype.Service;
 import com.michaelhyi.dao.UserRepository;
 import com.michaelhyi.entity.User;
 import com.michaelhyi.exception.UnauthorizedUserException;
 import com.michaelhyi.exception.UserNotFoundException;
 import com.michaelhyi.jwt.JwtService;
 import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
 
 @Service
 @AllArgsConstructor

--- a/api/src/main/java/com/michaelhyi/service/PostService.java
+++ b/api/src/main/java/com/michaelhyi/service/PostService.java
@@ -1,21 +1,19 @@
 package com.michaelhyi.service;
 
-import java.io.IOException;
-import java.util.List;
-
-import org.springframework.data.domain.Sort;
-import org.springframework.stereotype.Service;
-import org.springframework.web.multipart.MultipartFile;
-
 import com.michaelhyi.dao.PostRepository;
 import com.michaelhyi.dto.PostRequest;
 import com.michaelhyi.entity.Post;
 import com.michaelhyi.exception.PostNotFoundException;
 import com.michaelhyi.exception.S3ObjectNotFoundException;
 import com.michaelhyi.exception.S3ServiceException;
-
 import lombok.AllArgsConstructor;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
 import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
+
+import java.io.IOException;
+import java.util.List;
 
 @Service
 @AllArgsConstructor
@@ -28,7 +26,7 @@ public class PostService {
 
         if (repository.findById(post.getId()).isPresent()) {
             throw new IllegalArgumentException(
-                "A post with the same title already exists."
+                    "A post with the same title already exists."
             );
         }
 

--- a/api/src/main/java/com/michaelhyi/service/S3Service.java
+++ b/api/src/main/java/com/michaelhyi/service/S3Service.java
@@ -1,10 +1,9 @@
 package com.michaelhyi.service;
 
-import java.io.IOException;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.stereotype.Service;
 import com.michaelhyi.exception.S3ObjectNotFoundException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
 import software.amazon.awssdk.core.ResponseInputStream;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
@@ -12,6 +11,8 @@ import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectResponse;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+import java.io.IOException;
 
 @Service
 @RequiredArgsConstructor

--- a/api/src/test/java/com/michaelhyi/integration/AuthIT.java
+++ b/api/src/test/java/com/michaelhyi/integration/AuthIT.java
@@ -1,14 +1,15 @@
 package com.michaelhyi.integration;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.Map;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
+import com.michaelhyi.dao.UserRepository;
+import com.michaelhyi.dto.LoginRequest;
+import com.michaelhyi.entity.User;
+import com.michaelhyi.jwt.JwtService;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -26,16 +27,17 @@ import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.MySQLContainer;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.ObjectWriter;
-import com.michaelhyi.dao.UserRepository;
-import com.michaelhyi.dto.LoginRequest;
-import com.michaelhyi.entity.User;
-import com.michaelhyi.jwt.JwtService;
-import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.SignatureAlgorithm;
-import io.jsonwebtoken.io.Decoders;
-import io.jsonwebtoken.security.Keys;
+
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @AutoConfigureMockMvc
 @SpringBootTest(webEnvironment = RANDOM_PORT)
@@ -44,7 +46,7 @@ class AuthIT {
     private static final int REDIS_PORT = 6379;
     static MySQLContainer<?> mysql = new MySQLContainer<>("mysql:8.0.36");
     static GenericContainer<?> redis = new GenericContainer<>("redis:6.2.14")
-                                            .withExposedPorts(REDIS_PORT);
+            .withExposedPorts(REDIS_PORT);
 
     @DynamicPropertySource
     static void configureProperties(DynamicPropertyRegistry registry) {
@@ -52,7 +54,7 @@ class AuthIT {
         registry.add("spring.datasource.username", mysql::getUsername);
         registry.add("spring.datasource.password", mysql::getPassword);
         registry.add("spring.data.redis.host", redis::getHost);
-        registry.add("spring.data.redis.port", () -> String.valueOf(redis.getMappedPort(REDIS_PORT))); 
+        registry.add("spring.data.redis.port", () -> String.valueOf(redis.getMappedPort(REDIS_PORT)));
     }
 
     @Autowired
@@ -81,13 +83,13 @@ class AuthIT {
     void setUp() {
         repository.deleteAll();
         writer = mapper.writer().withDefaultPrettyPrinter();
-    } 
+    }
 
     @AfterEach
     void tearDown() {
         cacheManager.getCacheNames()
-                    .parallelStream()
-                    .forEach(n -> cacheManager.getCache(n).clear());
+                .parallelStream()
+                .forEach(n -> cacheManager.getCache(n).clear());
     }
 
     @AfterAll
@@ -102,37 +104,37 @@ class AuthIT {
         repository.save(alreadyExists);
 
         String res = mvc.perform(post("/v1/auth/login")
-                                    .contentType(MediaType.APPLICATION_JSON)
-                                    .content(writer.writeValueAsString(new LoginRequest("alreadyexists@mail.com"))))
-                        .andExpect(status().isOk())
-                        .andReturn()
-                        .getResponse()
-                        .getContentAsString();
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(writer.writeValueAsString(new LoginRequest("alreadyexists@mail.com"))))
+                .andExpect(status().isOk())
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
 
         assertTrue(jwtService.isTokenValid(res, alreadyExists));
         assertEquals(alreadyExists.getEmail(), jwtService.extractUsername(res));
 
         String error = mvc.perform(post("/v1/auth/login")
-                            .contentType(MediaType.APPLICATION_JSON)
-                            .content(writer.writeValueAsString(new LoginRequest("unauthorized@mail.com"))))
-                            .andExpect(status().isUnauthorized())
-                            .andReturn()
-                            .getResolvedException()
-                            .getMessage();
-        
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(writer.writeValueAsString(new LoginRequest("unauthorized@mail.com"))))
+                .andExpect(status().isUnauthorized())
+                .andReturn()
+                .getResolvedException()
+                .getMessage();
+
         assertEquals("Unauthorized.", error);
 
         res = mvc.perform(post("/v1/auth/login")
-                            .contentType(MediaType.APPLICATION_JSON)
-                            .content(writer.writeValueAsString(new LoginRequest("test@mail.com"))))
-                    .andExpect(status().isOk())
-                    .andReturn()
-                    .getResponse()
-                    .getContentAsString();
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(writer.writeValueAsString(new LoginRequest("test@mail.com"))))
+                .andExpect(status().isOk())
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
 
         User expected = repository
-                            .findById("test@mail.com")
-                            .get();
+                .findById("test@mail.com")
+                .get();
 
         assertTrue(jwtService.isTokenValid(res, expected));
         assertEquals(expected.getEmail(), jwtService.extractUsername(res));
@@ -140,26 +142,28 @@ class AuthIT {
 
     @Test
     void validateToken() throws Exception {
-        User user = new User("test@mail.com"); 
+        User user = new User("test@mail.com");
         String token = jwtService.generateToken(user);
 
-        String error = mvc.perform(get("/v1/auth/validate-token/" + token))
-                            .andExpect(status().isNotFound())
-                            .andReturn()
-                            .getResolvedException()
-                            .getMessage();
-        
+        String error = mvc.perform(get("/v1/auth/validate-token")
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isNotFound())
+                .andReturn()
+                .getResolvedException()
+                .getMessage();
+
         assertEquals("User not found.", error);
-        
+
         repository.save(user);
 
         String unauthorizedToken = generateUnauthorizedToken(user);
 
-        error = mvc.perform(get("/v1/auth/validate-token/" + unauthorizedToken))
-            .andExpect(status().isUnauthorized())
-            .andReturn()
-            .getResolvedException()
-            .getMessage();
+        error = mvc.perform(get("/v1/auth/validate-token")
+                        .header("Authorization", "Bearer " + unauthorizedToken))
+                .andExpect(status().isUnauthorized())
+                .andReturn()
+                .getResolvedException()
+                .getMessage();
 
         assertEquals("Unauthorized.", error);
 
@@ -167,17 +171,19 @@ class AuthIT {
                 + ".eyJzdWIiOiJ0ZXN0QG1haWwuY29tIiwiaWF0IjoxNzA5MzI0OTUxLCJleHAiOjE3MDkzMjQ5NTF9"
                 + ".0kgPiP5MELw6Pq6i9tJMXDxDy7n4Eu-LprqHOD4O2QM";
 
-        error = mvc.perform(get("/v1/auth/validate-token/" + expiredToken))
-            .andExpect(status().isUnauthorized())
-            .andReturn()
-            .getResolvedException()
-            .getMessage();
+        error = mvc.perform(get("/v1/auth/validate-token")
+                        .header("Authorization", "Bearer " + expiredToken))
+                .andExpect(status().isUnauthorized())
+                .andReturn()
+                .getResolvedException()
+                .getMessage();
 
         assertEquals("Unauthorized.", error);
 
-        mvc.perform(get("/v1/auth/validate-token/" + token))
-            .andExpect(status().isOk());
-        
+        mvc.perform(get("/v1/auth/validate-token")
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isOk());
+
     }
 
     private String generateUnauthorizedToken(UserDetails details) {
@@ -190,7 +196,7 @@ class AuthIT {
                 .setSubject(details.getUsername())
                 .setIssuedAt(new Date(System.currentTimeMillis()))
                 .setExpiration(new Date(
-                        System.currentTimeMillis() + 1L 
+                        System.currentTimeMillis() + 1L
                 ))
                 .signWith(Keys.hmacShaKeyFor(keyBytes), SignatureAlgorithm.HS256)
                 .compact();

--- a/api/src/test/java/com/michaelhyi/integration/AuthIT.java
+++ b/api/src/test/java/com/michaelhyi/integration/AuthIT.java
@@ -146,7 +146,8 @@ class AuthIT {
         String token = jwtService.generateToken(user);
 
         String error = mvc.perform(get("/v1/auth/validate-token")
-                        .header("Authorization", "Bearer " + token))
+                        .header("Authorization", "Bearer " + token)
+                        .servletPath("/v1/auth/validate-token"))
                 .andExpect(status().isNotFound())
                 .andReturn()
                 .getResolvedException()
@@ -159,7 +160,8 @@ class AuthIT {
         String unauthorizedToken = generateUnauthorizedToken(user);
 
         error = mvc.perform(get("/v1/auth/validate-token")
-                        .header("Authorization", "Bearer " + unauthorizedToken))
+                        .header("Authorization", "Bearer " + unauthorizedToken)
+                        .servletPath("/v1/auth/validate-token"))
                 .andExpect(status().isUnauthorized())
                 .andReturn()
                 .getResolvedException()
@@ -172,7 +174,8 @@ class AuthIT {
                 + ".0kgPiP5MELw6Pq6i9tJMXDxDy7n4Eu-LprqHOD4O2QM";
 
         error = mvc.perform(get("/v1/auth/validate-token")
-                        .header("Authorization", "Bearer " + expiredToken))
+                        .header("Authorization", "Bearer " + expiredToken)
+                        .servletPath("/v1/auth/validate-token"))
                 .andExpect(status().isUnauthorized())
                 .andReturn()
                 .getResolvedException()

--- a/api/src/test/java/com/michaelhyi/unit/AuthServiceTest.java
+++ b/api/src/test/java/com/michaelhyi/unit/AuthServiceTest.java
@@ -1,24 +1,26 @@
 package com.michaelhyi.unit;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.when;
-import java.util.List;
-import java.util.Optional;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
 import com.michaelhyi.dao.UserRepository;
 import com.michaelhyi.entity.User;
 import com.michaelhyi.exception.UnauthorizedUserException;
 import com.michaelhyi.exception.UserNotFoundException;
 import com.michaelhyi.jwt.JwtService;
 import com.michaelhyi.service.AuthService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class AuthServiceTest {

--- a/api/src/test/java/com/michaelhyi/unit/PostServiceTest.java
+++ b/api/src/test/java/com/michaelhyi/unit/PostServiceTest.java
@@ -1,15 +1,12 @@
 package com.michaelhyi.unit;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.when;
-import java.util.Date;
-import java.util.Optional;
+import com.michaelhyi.dao.PostRepository;
+import com.michaelhyi.dto.PostRequest;
+import com.michaelhyi.entity.Post;
+import com.michaelhyi.exception.PostNotFoundException;
+import com.michaelhyi.exception.S3ObjectNotFoundException;
+import com.michaelhyi.service.PostService;
+import com.michaelhyi.service.S3Service;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -18,14 +15,19 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.Sort;
 import org.springframework.mock.web.MockMultipartFile;
-import com.michaelhyi.dao.PostRepository;
-import com.michaelhyi.dto.PostRequest;
-import com.michaelhyi.entity.Post;
-import com.michaelhyi.exception.PostNotFoundException;
-import com.michaelhyi.exception.S3ObjectNotFoundException;
-import com.michaelhyi.service.PostService;
-import com.michaelhyi.service.S3Service;
 import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
+
+import java.util.Date;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class PostServiceTest {
@@ -115,7 +117,7 @@ class PostServiceTest {
     @Test
     void willUpdateS3ObjectDuringCreatePostImageWhenImageAlreadyExists() {
         when(repository.findById("title"))
-            .thenReturn(Optional.of(post));
+                .thenReturn(Optional.of(post));
         when(s3Service.getObject("title")).thenReturn("Hello World!".getBytes());
 
         underTest.createPostImage("title", new MockMultipartFile("file", "New Hello World!".getBytes()));
@@ -123,13 +125,13 @@ class PostServiceTest {
         verify(repository).findById("title");
         verify(s3Service).getObject("title");
         verify(s3Service).deleteObject("title");
-        verify(s3Service).putObject("title", "New Hello World!".getBytes()); 
+        verify(s3Service).putObject("title", "New Hello World!".getBytes());
     }
 
     @Test
     void createPostImage() {
         when(repository.findById("title"))
-            .thenReturn(Optional.of(post));
+                .thenReturn(Optional.of(post));
         when(s3Service.getObject("title")).thenThrow(NoSuchKeyException.class);
 
         underTest.createPostImage("title", new MockMultipartFile("file", "Hello World!".getBytes()));
@@ -203,9 +205,9 @@ class PostServiceTest {
     void willThrowUpdatePostWhenPostNotFound() {
         when(repository.findById("title")).thenReturn(Optional.empty());
 
-        assertThrows(PostNotFoundException.class, 
-                        () -> underTest.updatePost("title", new PostRequest("<h1>title (1994)</h1>content"))
-                    );
+        assertThrows(PostNotFoundException.class,
+                () -> underTest.updatePost("title", new PostRequest("<h1>title (1994)</h1>content"))
+        );
 
         verify(repository).findById("title");
         verifyNoMoreInteractions(repository);


### PR DESCRIPTION
## Summary

For token validation, moved the passed in JWT token to the Auth header.

## Changelog

- Refactored token validation and authorization for React components.
- Moved JWT token to Bearer token.

## Test Plan

- When testing token validation, move it to the Authorization header.