### PR TITLE
chore(keypairs): moved keypairs inside project, disabled git tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 bin
 build
 coverage
+keypairs
 node_modules
 
 .classpath


### PR DESCRIPTION
## Summary

Moved AWS EC2 instance keypairs inside project.

## Changelog

- Added `keypairs` directory to`.gitignore`

## Testing

N/A