### PR TITLE
refactor(api-version): moved api-version to application.properties [PW-268]

### DIFF
--- a/.github/workflows/backend-cd.yml
+++ b/.github/workflows/backend-cd.yml
@@ -21,6 +21,7 @@ jobs:
         working-directory: ./backend/src/main/resources
         run: |
           touch application.properties
+          echo "api.version-path=/v1" >> ./application.properties
           echo "auth.whitelisted-emails=${{ secrets.API_AUTH_WHITELISTED_EMAILS }}" >> ./application.properties
           echo "aws.access-key=${{ secrets.API_AWS_ACCESS_KEY }}" >> ./application.properties
           echo "aws.secret-key=${{ secrets.API_AWS_SECRET_KEY }}" >> ./application.properties
@@ -49,6 +50,7 @@ jobs:
         working-directory: ./backend/src/test/resources
         run: |
           touch application-it.properties
+          echo "api.version-path=/v1" >> ./application-it.properties
           echo "auth.whitelisted-emails=test@mail.com" >> ./application-it.properties
           echo "aws.s3.bucket=test" >> ./application-it.properties
           echo "security.cors.allowed-origins=*" >> ./application-it.properties

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -16,6 +16,7 @@ jobs:
         working-directory: ./backend/src/main/resources
         run: |
           touch application.properties
+          echo "api.version-path=/v1" >> ./application.properties
           echo "auth.whitelisted-emails=${{ secrets.API_AUTH_WHITELISTED_EMAILS }}" >> ./application.properties
           echo "aws.access-key=${{ secrets.API_AWS_ACCESS_KEY }}" >> ./application.properties
           echo "aws.secret-key=${{ secrets.API_AWS_SECRET_KEY }}" >> ./application.properties
@@ -44,6 +45,7 @@ jobs:
         working-directory: ./backend/src/test/resources
         run: |
           touch application-it.properties
+          echo "api.version-path=/v1" >> ./application-it.properties
           echo "auth.whitelisted-emails=test@mail.com" >> ./application-it.properties
           echo "aws.s3.bucket=test" >> ./application-it.properties
           echo "security.cors.allowed-origins=*" >> ./application-it.properties

--- a/SETUP.md
+++ b/SETUP.md
@@ -18,6 +18,8 @@ cd personal-website
 2. In `backend/src/main/resources`, create a file named `application.properties`. Copy the following into the file:
 
 ```shell
+api.version-path=/v1
+
 auth.whitelisted-emails=
 
 aws.access-key=

--- a/backend/src/main/java/com/michaelyi/auth/AuthController.java
+++ b/backend/src/main/java/com/michaelyi/auth/AuthController.java
@@ -11,7 +11,7 @@ import lombok.AllArgsConstructor;
 
 @RestController
 @AllArgsConstructor
-@RequestMapping("v1/auth")
+@RequestMapping("${api.version-path}/auth")
 public class AuthController {
     private final AuthService service;
 

--- a/backend/src/main/java/com/michaelyi/post/PostController.java
+++ b/backend/src/main/java/com/michaelyi/post/PostController.java
@@ -18,7 +18,7 @@ import lombok.AllArgsConstructor;
 
 @RestController
 @AllArgsConstructor
-@RequestMapping("v1/post")
+@RequestMapping("${api.version-path}/post")
 public class PostController {
     private final PostService service;
 

--- a/backend/src/test/java/com/michaelyi/auth/AuthIT.java
+++ b/backend/src/test/java/com/michaelyi/auth/AuthIT.java
@@ -1,16 +1,14 @@
 package com.michaelyi.auth;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
-import java.util.Date;
-import java.util.HashMap;
-import java.util.Map;
-
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
+import com.michaelyi.security.JwtService;
+import com.michaelyi.user.User;
+import com.michaelyi.user.UserRepository;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -29,25 +27,28 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.MySQLContainer;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.ObjectWriter;
-import com.michaelyi.security.JwtService;
-import com.michaelyi.user.User;
-import com.michaelyi.user.UserRepository;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
 
-import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.SignatureAlgorithm;
-import io.jsonwebtoken.io.Decoders;
-import io.jsonwebtoken.security.Keys;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @AutoConfigureMockMvc
 @SpringBootTest(webEnvironment = RANDOM_PORT)
 @TestPropertySource("classpath:application-it.properties")
 class AuthIT {
     private static final int REDIS_PORT = 6379;
-    private static MySQLContainer<?> mysql = new MySQLContainer<>("mysql:8.0.36");
-    private static GenericContainer<?> redis = new GenericContainer<>("redis:6.2.14")
-            .withExposedPorts(REDIS_PORT);
+    private static MySQLContainer<?> mysql = new MySQLContainer<>(
+            "mysql:8.0.36"
+    );
+    private static GenericContainer<?> redis =
+            new GenericContainer<>("redis:6.2.14")
+                    .withExposedPorts(REDIS_PORT);
 
     @DynamicPropertySource
     static void configureProperties(DynamicPropertyRegistry registry) {
@@ -55,7 +56,9 @@ class AuthIT {
         registry.add("spring.datasource.username", mysql::getUsername);
         registry.add("spring.datasource.password", mysql::getPassword);
         registry.add("spring.data.redis.host", redis::getHost);
-        registry.add("spring.data.redis.port", () -> String.valueOf(redis.getMappedPort(REDIS_PORT)));
+        registry.add("spring.data.redis.port", () -> String.valueOf(
+                redis.getMappedPort(REDIS_PORT)
+        ));
     }
 
     @Autowired
@@ -103,10 +106,11 @@ class AuthIT {
     void login() throws Exception {
         User alreadyExists = new User("alreadyexists@mail.com");
         repository.save(alreadyExists);
+        AuthLoginRequest req = new AuthLoginRequest("alreadyexists@mail.com");
 
         String res = mvc.perform(post("/v1/auth/login")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(writer.writeValueAsString(new AuthLoginRequest("alreadyexists@mail.com"))))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(writer.writeValueAsString(req)))
                 .andExpect(status().isOk())
                 .andReturn()
                 .getResponse()
@@ -115,9 +119,11 @@ class AuthIT {
         assertTrue(jwtService.isTokenValid(res, alreadyExists));
         assertEquals(alreadyExists.getEmail(), jwtService.extractUsername(res));
 
+        req = new AuthLoginRequest("unauthorized@mail.com");
+
         String error = mvc.perform(post("/v1/auth/login")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(writer.writeValueAsString(new AuthLoginRequest("unauthorized@mail.com"))))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(writer.writeValueAsString(req)))
                 .andExpect(status().isUnauthorized())
                 .andReturn()
                 .getResolvedException()
@@ -125,9 +131,10 @@ class AuthIT {
 
         assertEquals("Unauthorized.", error);
 
+        req = new AuthLoginRequest("test@mail.com");
         res = mvc.perform(post("/v1/auth/login")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(writer.writeValueAsString(new AuthLoginRequest("test@mail.com"))))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(writer.writeValueAsString(req)))
                 .andExpect(status().isOk())
                 .andReturn()
                 .getResponse()
@@ -147,8 +154,11 @@ class AuthIT {
         String token = jwtService.generateToken(user);
 
         String error = mvc.perform(get("/v1/auth/validate-token")
-                .header("Authorization", "Bearer " + token)
-                .servletPath("/v1/auth/validate-token"))
+                        .header(
+                                "Authorization",
+                                String.format("Bearer %s", token)
+                        )
+                        .servletPath("/v1/auth/validate-token"))
                 .andExpect(status().isNotFound())
                 .andReturn()
                 .getResolvedException()
@@ -161,8 +171,11 @@ class AuthIT {
         String unauthorizedToken = generateUnauthorizedToken(user);
 
         error = mvc.perform(get("/v1/auth/validate-token")
-                .header("Authorization", "Bearer " + unauthorizedToken)
-                .servletPath("/v1/auth/validate-token"))
+                        .header(
+                                "Authorization",
+                                String.format("Bearer %s", unauthorizedToken)
+                        )
+                        .servletPath("/v1/auth/validate-token"))
                 .andExpect(status().isUnauthorized())
                 .andReturn()
                 .getResolvedException()
@@ -171,12 +184,16 @@ class AuthIT {
         assertEquals("Unauthorized.", error);
 
         final String expiredToken = "eyJhbGciOiJIUzI1NiJ9"
-                + ".eyJzdWIiOiJ0ZXN0QG1haWwuY29tIiwiaWF0IjoxNzA5MzI0OTUxLCJleHAiOjE3MDkzMjQ5NTF9"
+                + ".eyJzdWIiOiJ0ZXN0QG1haWwuY29tIiwiaWF0IjoxNzA5MzI0OTUxLCJleHA"
+                + "iOjE3MDkzMjQ5NTF9"
                 + ".0kgPiP5MELw6Pq6i9tJMXDxDy7n4Eu-LprqHOD4O2QM";
 
         error = mvc.perform(get("/v1/auth/validate-token")
-                .header("Authorization", "Bearer " + expiredToken)
-                .servletPath("/v1/auth/validate-token"))
+                        .header(
+                                "Authorization",
+                                String.format("Bearer %s", expiredToken)
+                        )
+                        .servletPath("/v1/auth/validate-token"))
                 .andExpect(status().isUnauthorized())
                 .andReturn()
                 .getResolvedException()
@@ -185,14 +202,19 @@ class AuthIT {
         assertEquals("Unauthorized.", error);
 
         mvc.perform(get("/v1/auth/validate-token")
-                .header("Authorization", "Bearer " + token))
+                        .header("Authorization",
+                                String.format("Bearer %s", token)))
                 .andExpect(status().isOk());
 
     }
 
     private String generateUnauthorizedToken(UserDetails details) {
         Map<String, Object> extraClaims = new HashMap<>();
-        byte[] keyBytes = Decoders.BASE64.decode("fakesigninkeyfakesigninkeyfakesigninkeyfakesigninkey");
+        byte[] keyBytes = Decoders
+                .BASE64
+                .decode(
+                        "fakesigninkeyfakesigninkeyfakesigninkeyfakesigninkey"
+                );
 
         return Jwts
                 .builder()
@@ -201,7 +223,10 @@ class AuthIT {
                 .setIssuedAt(new Date(System.currentTimeMillis()))
                 .setExpiration(new Date(
                         System.currentTimeMillis() + 1L))
-                .signWith(Keys.hmacShaKeyFor(keyBytes), SignatureAlgorithm.HS256)
+                .signWith(
+                        Keys.hmacShaKeyFor(keyBytes),
+                        SignatureAlgorithm.HS256
+                )
                 .compact();
     }
 }

--- a/backend/src/test/java/com/michaelyi/auth/AuthServiceTest.java
+++ b/backend/src/test/java/com/michaelyi/auth/AuthServiceTest.java
@@ -53,7 +53,8 @@ class AuthServiceTest {
 
     @Test
     void willThrowLoginWhenUnauthorized() {
-        assertThrows(UnauthorizedException.class, () -> underTest.login(UNAUTHORIZED_EMAIL));
+        assertThrows(UnauthorizedException.class, () ->
+                underTest.login(UNAUTHORIZED_EMAIL));
         verify(repository).findById(UNAUTHORIZED_EMAIL);
         verifyNoMoreInteractions(repository);
         verifyNoInteractions(jwtService);
@@ -73,7 +74,8 @@ class AuthServiceTest {
         when(jwtService.extractUsername(TOKEN)).thenReturn(EMAIL);
         when(repository.findById(EMAIL)).thenReturn(Optional.empty());
 
-        assertThrows(UserNotFoundException.class, () -> underTest.validateToken(BEARER_TOKEN));
+        assertThrows(UserNotFoundException.class,
+                () -> underTest.validateToken(BEARER_TOKEN));
         verify(jwtService).extractUsername(TOKEN);
         verify(repository).findById(EMAIL);
         verifyNoMoreInteractions(jwtService);
@@ -87,7 +89,8 @@ class AuthServiceTest {
         when(repository.findById(EMAIL)).thenReturn(Optional.of(user));
         when(jwtService.isTokenValid(TOKEN, user)).thenReturn(false);
 
-        assertThrows(UnauthorizedException.class, () -> underTest.validateToken(BEARER_TOKEN));
+        assertThrows(UnauthorizedException.class,
+                () -> underTest.validateToken(BEARER_TOKEN));
         verify(jwtService).extractUsername(TOKEN);
         verify(repository).findById(EMAIL);
         verify(jwtService).isTokenValid(TOKEN, user);

--- a/backend/src/test/java/com/michaelyi/post/PostServiceTest.java
+++ b/backend/src/test/java/com/michaelyi/post/PostServiceTest.java
@@ -1,5 +1,20 @@
 package com.michaelyi.post;
 
+import com.michaelyi.s3.S3Service;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Sort;
+import org.springframework.mock.web.MockMultipartFile;
+import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
+
+import java.util.Date;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
@@ -9,23 +24,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
-import java.util.Date;
-import java.util.NoSuchElementException;
-import java.util.Optional;
-
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.data.domain.Sort;
-import org.springframework.mock.web.MockMultipartFile;
-
-import com.michaelyi.s3.S3Service;
-
-import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
-
 @ExtendWith(MockitoExtension.class)
 class PostServiceTest {
     @Mock
@@ -34,7 +32,12 @@ class PostServiceTest {
     @Mock
     private S3Service s3Service;
     private PostService underTest;
-    private static final Post POST = new Post("title", new Date(), "title", "content");
+    private static final Post POST = new Post(
+            "title",
+            new Date(),
+            "title",
+            "content"
+    );
 
     @BeforeEach
     void setUp() {
@@ -43,11 +46,26 @@ class PostServiceTest {
 
     @Test
     void willThrowPostConstructorWhenBadRequest() {
-        assertThrows(IllegalArgumentException.class, () -> new Post(null));
-        assertThrows(IllegalArgumentException.class, () -> new Post(""));
-        assertThrows(IllegalArgumentException.class, () -> new Post("no-title"));
-        assertThrows(IllegalArgumentException.class, () -> new Post("<h1></h1>"));
-        assertThrows(IllegalArgumentException.class, () -> new Post("<h1>no-content</h1>"));
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> new Post(null)
+        );
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> new Post("")
+        );
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> new Post("no-title")
+        );
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> new Post("<h1></h1>")
+        );
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> new Post("<h1>no-content</h1>")
+        );
 
         String text = "<h1>title (1994)</h1>content";
         Post newPost = new Post(text);
@@ -64,7 +82,10 @@ class PostServiceTest {
         text = "<h1>It's Such A Beautiful Day (2012)</h1>Don Hertzfeldt";
         newPost = new Post(text);
         assertEquals("its-such-a-beautiful-day", newPost.getId());
-        assertEquals("It's Such A Beautiful Day (2012)", newPost.getTitle());
+        assertEquals(
+                "It's Such A Beautiful Day (2012)",
+                newPost.getTitle()
+        );
         assertEquals("Don Hertzfeldt", newPost.getContent());
     }
 
@@ -73,7 +94,10 @@ class PostServiceTest {
         when(repository.findById("title")).thenReturn(Optional.of(POST));
 
         assertThrows(IllegalArgumentException.class, () ->
-                underTest.createPost("<h1>title (1994)</h1><p>content</p>", null));
+                underTest.createPost(
+                        "<h1>title (1994)</h1><p>content</p>",
+                        null)
+        );
         verify(repository).findById("title");
         verifyNoMoreInteractions(repository);
     }
@@ -81,21 +105,29 @@ class PostServiceTest {
     @Test
     void willThrowCreatePostWhenImageDoesNotExist() {
         assertThrows(IllegalArgumentException.class, () ->
-                underTest.createPost("<h1>title (1994)</h1><p>content</p>", null));
+                underTest.createPost(
+                        "<h1>title (1994)</h1><p>content</p>",
+                        null
+                )
+        );
         verify(repository).findById("title");
         verifyNoMoreInteractions(repository);
     }
 
     @Test
     void createPost() {
-        when(repository.findById(POST.getId())).thenReturn(Optional.empty());
+        when(repository.findById(POST.getId())).thenReturn(
+                Optional.empty()
+        );
 
         String actualId = underTest.createPost(
                 "<h1>title (1994)</h1>content",
                 new MockMultipartFile("image", "Hello World!".getBytes())
         );
 
-        ArgumentCaptor<Post> postArgumentCaptor = ArgumentCaptor.forClass(Post.class);
+        ArgumentCaptor<Post> postArgumentCaptor = ArgumentCaptor.forClass(
+                Post.class
+        );
 
         verify(repository).findById(POST.getId());
         verify(repository).saveAndFlush(postArgumentCaptor.capture());
@@ -112,7 +144,10 @@ class PostServiceTest {
     void willThrowReadPostWhenPostNotFound() {
         when(repository.findById("title")).thenReturn(Optional.empty());
 
-        assertThrows(NoSuchElementException.class, () -> underTest.readPost("title"));
+        assertThrows(
+                NoSuchElementException.class,
+                () -> underTest.readPost("title")
+        );
         verify(repository).findById("title");
     }
 
@@ -132,7 +167,10 @@ class PostServiceTest {
     void willThrowReadPostImageWhenPostNotFound() {
         when(repository.findById("title")).thenReturn(Optional.empty());
 
-        assertThrows(NoSuchElementException.class, () -> underTest.readPostImage("title"));
+        assertThrows(
+                NoSuchElementException.class,
+                () -> underTest.readPostImage("title")
+        );
         verify(repository).findById("title");
         verify(s3Service, never()).getObject(any());
     }
@@ -140,9 +178,13 @@ class PostServiceTest {
     @Test
     void willThrowReadPostImageWhenS3KeyNotFound() {
         when(repository.findById("title")).thenReturn(Optional.of(POST));
-        when(s3Service.getObject("title")).thenThrow(NoSuchKeyException.class);
+        when(s3Service.getObject("title"))
+                .thenThrow(NoSuchKeyException.class);
 
-        assertThrows(NoSuchElementException.class, () -> underTest.readPostImage("title"));
+        assertThrows(
+                NoSuchElementException.class,
+                () -> underTest.readPostImage("title")
+        );
         verify(repository).findById("title");
         verify(s3Service).getObject("title");
     }
@@ -164,7 +206,9 @@ class PostServiceTest {
     @Test
     void readAllPosts() {
         underTest.readAllPosts();
-        verify(repository).findAll(Sort.by(Sort.Direction.DESC, "date"));
+        verify(repository).findAll(
+                Sort.by(Sort.Direction.DESC, "date")
+        );
     }
 
     @Test
@@ -172,7 +216,11 @@ class PostServiceTest {
         when(repository.findById("title")).thenReturn(Optional.empty());
 
         assertThrows(NoSuchElementException.class,
-                () -> underTest.updatePost("title", "<h1>title (1994)</h1>content", null)
+                () -> underTest.updatePost(
+                        "title",
+                        "<h1>title (1994)</h1>content",
+                        null
+                )
         );
 
         verify(repository).findById("title");
@@ -183,9 +231,14 @@ class PostServiceTest {
     void updatePost() {
         when(repository.findById("title")).thenReturn(Optional.of(POST));
 
-        underTest.updatePost("title", "<h1>title (1994)</h1>content", null);
+        underTest.updatePost(
+                "title",
+                "<h1>title (1994)</h1>content",
+                null
+        );
 
-        ArgumentCaptor<Post> postArgumentCaptor = ArgumentCaptor.forClass(Post.class);
+        ArgumentCaptor<Post> postArgumentCaptor =
+                ArgumentCaptor.forClass(Post.class);
 
         verify(repository, times(2)).findById("title");
         verify(repository).save(postArgumentCaptor.capture());
@@ -196,9 +249,17 @@ class PostServiceTest {
     void updatePostImage() {
         when(repository.findById("title")).thenReturn(Optional.of(POST));
 
-        underTest.updatePost("title", "<h1>title (1994)</h1>content", new MockMultipartFile("image", "New Hello World!".getBytes()));
+        underTest.updatePost(
+                "title",
+                "<h1>title (1994)</h1>content",
+                new MockMultipartFile(
+                        "image",
+                        "New Hello World!".getBytes()
+                )
+        );
 
-        ArgumentCaptor<Post> postArgumentCaptor = ArgumentCaptor.forClass(Post.class);
+        ArgumentCaptor<Post> postArgumentCaptor =
+                ArgumentCaptor.forClass(Post.class);
 
         verify(repository, times(2)).findById("title");
         verify(repository).save(postArgumentCaptor.capture());
@@ -211,7 +272,10 @@ class PostServiceTest {
     void willThrowDeletePostWhenPostNotFound() {
         when(repository.findById("title")).thenReturn(Optional.empty());
 
-        assertThrows(NoSuchElementException.class, () -> underTest.deletePost("title"));
+        assertThrows(
+                NoSuchElementException.class,
+                () -> underTest.deletePost("title")
+        );
         verifyNoMoreInteractions(s3Service);
         verifyNoMoreInteractions(repository);
     }


### PR DESCRIPTION
## Summary

Centralized context path with API version by setting it as a property

## Changelog

- Created property called `api.version-path`
- Fixed checkstyle violations across tests
- Updated docs accordingly

## Testing

- Ensure 100% coverage of tests