### PR TITLE
feat(ci/cd): removed deprecated dependencies from ci/cd pipeline [PW-275]

### DIFF
--- a/.github/workflows/backend-cd.yml
+++ b/.github/workflows/backend-cd.yml
@@ -16,7 +16,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup Java
         uses: actions/setup-java@v3
         with:
@@ -25,7 +25,7 @@ jobs:
           cache: 'gradle'
 
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@v3
+        uses: gradle/actions/setup-gradle@v3
 
       - name: Build
         working-directory: ./backend
@@ -41,7 +41,7 @@ jobs:
     needs: build 
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Download .jar File 
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -11,7 +11,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup Java
         uses: actions/setup-java@v3
         with:
@@ -20,7 +20,7 @@ jobs:
           cache: 'gradle'
 
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@v3
+        uses: gradle/actions/setup-gradle@v3
 
       - name: Build
         working-directory: ./backend
@@ -29,7 +29,7 @@ jobs:
   setup-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Create application.properties
         working-directory: ./backend/src/main/resources
         env:
@@ -91,7 +91,7 @@ jobs:
     needs: setup-test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup Java
         uses: actions/setup-java@v3
         with:
@@ -100,7 +100,7 @@ jobs:
           cache: 'gradle'
 
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@v3
+        uses: gradle/actions/setup-gradle@v3
 
       - name: Download application.properties 
         uses: actions/download-artifact@v4

--- a/.github/workflows/frontend-admin-cd.yml
+++ b/.github/workflows/frontend-admin-cd.yml
@@ -16,7 +16,7 @@ jobs:
       VERSION: 1.0.5
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/frontend-admin-ci.yml
+++ b/.github/workflows/frontend-admin-ci.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/frontend-web-cd.yml
+++ b/.github/workflows/frontend-web-cd.yml
@@ -16,7 +16,7 @@ jobs:
       VERSION: 5.0.6
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/frontend-web-ci.yml
+++ b/.github/workflows/frontend-web-ci.yml
@@ -11,7 +11,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
## Summary

Updated deprecated dependencies from CI/CD pipeline.

## Changelog

- Replaced `uses: actions/checkout@v3` with `uses: actions/checkout@v4`
- Replaced `uses: gradle/gradle-build-action@v3` with `uses: gradle/actions/setup-gradle@v3`

## Testing

N/A