### PR TITLE
fix(security): fixed endpoints return 403

### DIFF
--- a/backend/src/main/java/com/michaelyi/auth/AuthController.java
+++ b/backend/src/main/java/com/michaelyi/auth/AuthController.java
@@ -8,11 +8,11 @@ import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import static com.michaelyi.util.Constants.API_ENDPOINT_VERSION_PREFIX;
+import static com.michaelyi.util.Constants.CONTEXT_PATH;
 
 @RestController
 @AllArgsConstructor
-@RequestMapping(API_ENDPOINT_VERSION_PREFIX + "/auth")
+@RequestMapping(CONTEXT_PATH + "/auth")
 public class AuthController {
     private final AuthService service;
 

--- a/backend/src/main/java/com/michaelyi/post/PostController.java
+++ b/backend/src/main/java/com/michaelyi/post/PostController.java
@@ -15,11 +15,11 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
-import static com.michaelyi.util.Constants.API_ENDPOINT_VERSION_PREFIX;
+import static com.michaelyi.util.Constants.CONTEXT_PATH;
 
 @RestController
 @AllArgsConstructor
-@RequestMapping(API_ENDPOINT_VERSION_PREFIX + "/post")
+@RequestMapping(CONTEXT_PATH + "/post")
 public class PostController {
     private final PostService service;
 

--- a/backend/src/main/java/com/michaelyi/util/Constants.java
+++ b/backend/src/main/java/com/michaelyi/util/Constants.java
@@ -36,8 +36,10 @@ public class Constants {
     // Security 
     public static final String ADMIN_EMAIL = "admin@michael-yi.com";
     public static final String ADMIN_ROLE = "ADMIN";
-    public static final String AUTH_ENDPOINTS = "/v1/auth/**";
-    public static final String POST_ENDPOINTS = "/v1/post/**";
+    public static final String AUTH_ENDPOINTS
+        = API_ENDPOINT_VERSION_PREFIX + "/auth/**";
+    public static final String POST_ENDPOINTS
+        = API_ENDPOINT_VERSION_PREFIX + "/post/**";
     public static final int BEARER_PREFIX_LENGTH = 7;
     public static final long JWT_EXPIRATION = 6048000000L;
 }

--- a/backend/src/main/java/com/michaelyi/util/Constants.java
+++ b/backend/src/main/java/com/michaelyi/util/Constants.java
@@ -30,16 +30,16 @@ public class Constants {
             = "${security.jwt.secret-key}";
 
     // REST Controller
-    public static final String API_ENDPOINT_VERSION_PREFIX 
+    public static final String CONTEXT_PATH
         = "/v#{'${spring.application.version}'.split('[.]')[0]}";
 
     // Security 
     public static final String ADMIN_EMAIL = "admin@michael-yi.com";
     public static final String ADMIN_ROLE = "ADMIN";
     public static final String AUTH_ENDPOINTS
-        = API_ENDPOINT_VERSION_PREFIX + "/auth/**";
+        = CONTEXT_PATH + "/auth/**";
     public static final String POST_ENDPOINTS
-        = API_ENDPOINT_VERSION_PREFIX + "/post/**";
+        = CONTEXT_PATH + "/post/**";
     public static final int BEARER_PREFIX_LENGTH = 7;
     public static final long JWT_EXPIRATION = 6048000000L;
 }


### PR DESCRIPTION
## Summary

Fixed the wrong api version prefix for context path being whitelisted in Spring Security, resulting in 403 for all endpoints.

## Changelog

- Added `CONTEXT_PATH` in security whitelisted endpoints

## Testing

- Tested locally