### PR TITLE
fix(security): fixed endpoints return 403

### DIFF
--- a/.github/workflows/backend-cd.yml
+++ b/.github/workflows/backend-cd.yml
@@ -73,7 +73,6 @@ jobs:
             sudo docker pull michaelyi/personal-website-api:latest
             sudo docker run --name personal-website-api -d -p 8080:8080 \
               -e SPRING_APPLICATION_NAME=personal-website-api \
-              -e SPRING_APPLICATION_VERSION=${{ env.VERSION }} \
               -e AWS_ACCESS_KEY=${{ secrets.API_AWS_ACCESS_KEY }} \
               -e AWS_SECRET_KEY=${{ secrets.API_AWS_SECRET_KEY }} \
               -e AWS_S3_BUCKET=${{ secrets.API_AWS_S3_BUCKET }} \

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -37,7 +37,6 @@ jobs:
         run: |
           touch application.properties
           echo "spring.application.name=personal-website-api" >> ./application.properties
-          echo "spring.application.version=1.0.0" >> ./application.properties
           echo "aws.access-key=${{ secrets.API_AWS_ACCESS_KEY }}" >> ./application.properties
           echo "aws.secret-key=${{ secrets.API_AWS_SECRET_KEY }}" >> ./application.properties
           echo "aws.s3.bucket=${{ secrets.API_AWS_S3_BUCKET }}" >> ./application.properties
@@ -65,7 +64,6 @@ jobs:
           TEST_SECURITY_AUTH_ADMIN_PW: ${{ secrets.API_TEST_SECURITY_AUTH_ADMIN_PW }}
         run: |
           touch application-it.properties
-          echo "spring.application.version=1.0.0" >> ./application-it.properties
           echo "aws.s3.bucket=test" >> ./application-it.properties
           echo "spring.application.name=personal-website-api" >> ./application-it.properties
           echo "spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver" >> ./application-it.properties

--- a/SETUP.md
+++ b/SETUP.md
@@ -18,45 +18,44 @@ cd personal-website
 2. In `backend/src/main/resources`, create a file named `application.properties`. Copy the following into the file:
 
 ```shell
-api.version-path=/v1
+# app
+spring.application.name=personal-website-api
 
-auth.admin-pw=
-
+# aws
 aws.access-key=
 aws.secret-key=
 aws.s3.bucket=
 
-security.cors.allowed-origins=http://localhost:3000,http://localhost:3001
-security.jwt.secret-key=
-
-spring.application.name=personal-website-api
-
+# db
 spring.datasource.url=jdbc:mysql://localhost:3306/personal_website_api
 spring.datasource.username=root
 spring.datasource.password=root
-spring.jpa.hibernate.ddl-auto=update
-
+spring.jpa.hibernate.ddl-auto=validate
 spring.data.redis.host=localhost
 spring.data.redis.port=6379
 
+# security
+security.auth.admin-pw=
+security.cors.allowed-origins=http://localhost:3000,http://localhost:3001
+security.jwt.secret-key=
+
+# upload
 spring.servlet.multipart.max-file-size=10MB
 spring.servlet.multipart.max-request-size=10MB
 ```
-
-- In `application.properties`, set `auth.admin-pw` equal to a secure, hashed password. Generate one using `openssl` or any password manager.
 
 > To generate AWS secret keys, log in to your [AWS console](https://aws.amazon.com/). Click on your username, and click `Security credentials` on the dropdown menu. Scroll down to `Access keys`, and click `Create access key`.
 
 - Set `aws.access-key` equal to your AWS Access Key in both files.
 - Set `aws.secret-key` equal to your AWS Secret Key in both files.
 
-> Use `openssl rand -base64 512` to generate a secret key for JWT signing.
-
-- Set `security.jwt.secret-key` equal to your generated secret key in both files.
-
 > Using the instructions [here](https://github.com/michaelhyi/personal-website/blob/prod/DEPLOY.md) on how to create a MySQL database server using AWS EC2 instances, create a test MySQL server. 
-- Update `spring.datasource.url`, `spring.datasource.username`, and `spring.datasource.password` to reflect the configuration to your test server.
 - Add the following property to `application-it.properties`: `spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver`.
+
+- Set `security.auth.admin-pw` equal to a secure, hashed password. Generate one using `openssl` or any password manager.
+
+> Use `openssl rand -base64 512` to generate a secret key for JWT signing.
+- Set `security.jwt.secret-key` equal to your generated secret key in both files.
 
 3. Create a new MySQL database. 
 

--- a/backend/src/main/java/com/michaelyi/auth/AuthController.java
+++ b/backend/src/main/java/com/michaelyi/auth/AuthController.java
@@ -8,11 +8,9 @@ import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import static com.michaelyi.util.Constants.CONTEXT_PATH;
-
 @RestController
 @AllArgsConstructor
-@RequestMapping(CONTEXT_PATH + "/auth")
+@RequestMapping("/v2/auth")
 public class AuthController {
     private final AuthService service;
 

--- a/backend/src/main/java/com/michaelyi/auth/AuthController.java
+++ b/backend/src/main/java/com/michaelyi/auth/AuthController.java
@@ -8,11 +8,11 @@ import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import static com.michaelyi.util.Constants.API_ENDPOINT_VERSION_PREFIX;
+import static com.michaelyi.util.Constants.CONTEXT_PATH;
 
 @RestController
 @AllArgsConstructor
-@RequestMapping(API_ENDPOINT_VERSION_PREFIX + "/auth")
+@RequestMapping(CONTEXT_PATH + "/auth")
 public class AuthController {
     private final AuthService service;
 

--- a/backend/src/main/java/com/michaelyi/post/PostController.java
+++ b/backend/src/main/java/com/michaelyi/post/PostController.java
@@ -15,11 +15,11 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
-import static com.michaelyi.util.Constants.API_ENDPOINT_VERSION_PREFIX;
+import static com.michaelyi.util.Constants.CONTEXT_PATH;
 
 @RestController
 @AllArgsConstructor
-@RequestMapping(API_ENDPOINT_VERSION_PREFIX + "/post")
+@RequestMapping(CONTEXT_PATH + "/post")
 public class PostController {
     private final PostService service;
 

--- a/backend/src/main/java/com/michaelyi/post/PostController.java
+++ b/backend/src/main/java/com/michaelyi/post/PostController.java
@@ -15,11 +15,9 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
-import static com.michaelyi.util.Constants.CONTEXT_PATH;
-
 @RestController
 @AllArgsConstructor
-@RequestMapping(CONTEXT_PATH + "/post")
+@RequestMapping("/v2/post")
 public class PostController {
     private final PostService service;
 

--- a/backend/src/main/java/com/michaelyi/security/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/michaelyi/security/JwtAuthenticationFilter.java
@@ -29,7 +29,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             @NonNull HttpServletResponse response,
             @NonNull FilterChain filterChain
     ) throws ServletException, IOException {
-        if (request.getServletPath().contains("/v1/auth")) {
+        if (request.getServletPath().contains("/v2/auth")) {
             filterChain.doFilter(request, response);
             return;
         }

--- a/backend/src/main/java/com/michaelyi/util/Constants.java
+++ b/backend/src/main/java/com/michaelyi/util/Constants.java
@@ -29,16 +29,11 @@ public class Constants {
     public static final String SECURITY_JWT_SECRET_KEY
             = "${security.jwt.secret-key}";
 
-    // REST Controller
-    public static final String CONTEXT_PATH = "/v2";
-
-    // Security 
+    // Security
     public static final String ADMIN_EMAIL = "admin@michael-yi.com";
     public static final String ADMIN_ROLE = "ADMIN";
-    public static final String AUTH_ENDPOINTS
-            = CONTEXT_PATH + "/auth/**";
-    public static final String POST_ENDPOINTS
-            = CONTEXT_PATH + "/post/**";
+    public static final String AUTH_ENDPOINTS = "/v2/auth/**";
+    public static final String POST_ENDPOINTS = "/v2/post/**";
     public static final int BEARER_PREFIX_LENGTH = 7;
     public static final long JWT_EXPIRATION = 6048000000L;
 }

--- a/backend/src/main/java/com/michaelyi/util/Constants.java
+++ b/backend/src/main/java/com/michaelyi/util/Constants.java
@@ -30,14 +30,15 @@ public class Constants {
             = "${security.jwt.secret-key}";
 
     // REST Controller
-    public static final String API_ENDPOINT_VERSION_PREFIX 
-        = "/v#{'${spring.application.version}'.split('[.]')[0]}";
+    public static final String CONTEXT_PATH = "/v2";
 
     // Security 
     public static final String ADMIN_EMAIL = "admin@michael-yi.com";
     public static final String ADMIN_ROLE = "ADMIN";
-    public static final String AUTH_ENDPOINTS = "/v1/auth/**";
-    public static final String POST_ENDPOINTS = "/v1/post/**";
+    public static final String AUTH_ENDPOINTS
+            = CONTEXT_PATH + "/auth/**";
+    public static final String POST_ENDPOINTS
+            = CONTEXT_PATH + "/post/**";
     public static final int BEARER_PREFIX_LENGTH = 7;
     public static final long JWT_EXPIRATION = 6048000000L;
 }

--- a/backend/src/test/java/com/michaelyi/auth/AuthIT.java
+++ b/backend/src/test/java/com/michaelyi/auth/AuthIT.java
@@ -60,7 +60,7 @@ class AuthIT extends TestConfig {
     void login() throws Exception {
         LoginRequest req = new LoginRequest("unauthorized password");
 
-        String error = mvc.perform(post("/v1/auth/login")
+        String error = mvc.perform(post("/v2/auth/login")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(writer.writeValueAsString(req)))
                 .andExpect(status().isUnauthorized())
@@ -71,7 +71,7 @@ class AuthIT extends TestConfig {
         assertEquals("Unauthorized", error);
 
         req = new LoginRequest("authorized password");
-        String res = mvc.perform(post("/v1/auth/login")
+        String res = mvc.perform(post("/v2/auth/login")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(writer.writeValueAsString(req)))
                 .andExpect(status().isOk())
@@ -86,12 +86,12 @@ class AuthIT extends TestConfig {
     @Test
     void validateToken() throws Exception {
         String unauthorizedToken = generateUnauthorizedToken();
-        String error = mvc.perform(get("/v1/auth/validate-token")
+        String error = mvc.perform(get("/v2/auth/validate-token")
                         .header(
                                 "Authorization",
                                 String.format("Bearer %s", unauthorizedToken)
                         )
-                        .servletPath("/v1/auth/validate-token"))
+                        .servletPath("/v2/auth/validate-token"))
                 .andExpect(status().isUnauthorized())
                 .andReturn()
                 .getResolvedException()
@@ -99,12 +99,12 @@ class AuthIT extends TestConfig {
 
         assertEquals("Unauthorized", error);
 
-        error = mvc.perform(get("/v1/auth/validate-token")
+        error = mvc.perform(get("/v2/auth/validate-token")
                         .header(
                                 "Authorization",
                                 String.format("Bearer %s", EXPIRED_TOKEN)
                         )
-                        .servletPath("/v1/auth/validate-token"))
+                        .servletPath("/v2/auth/validate-token"))
                 .andExpect(status().isUnauthorized())
                 .andReturn()
                 .getResolvedException()
@@ -113,7 +113,7 @@ class AuthIT extends TestConfig {
         assertEquals("Unauthorized", error);
 
         LoginRequest req = new LoginRequest("authorized password");
-        String token = mvc.perform(post("/v1/auth/login")
+        String token = mvc.perform(post("/v2/auth/login")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(writer.writeValueAsString(req)))
                 .andExpect(status().isOk())
@@ -121,7 +121,7 @@ class AuthIT extends TestConfig {
                 .getResponse()
                 .getContentAsString();
 
-        mvc.perform(get("/v1/auth/validate-token")
+        mvc.perform(get("/v2/auth/validate-token")
                         .header("Authorization",
                                 String.format("Bearer %s", token)))
                 .andExpect(status().isOk());

--- a/backend/src/test/java/com/michaelyi/auth/AuthIT.java
+++ b/backend/src/test/java/com/michaelyi/auth/AuthIT.java
@@ -90,8 +90,7 @@ class AuthIT extends TestConfig {
                         .header(
                                 "Authorization",
                                 String.format("Bearer %s", unauthorizedToken)
-                        )
-                        .servletPath("/v2/auth/validate-token"))
+                        ))
                 .andExpect(status().isUnauthorized())
                 .andReturn()
                 .getResolvedException()
@@ -103,8 +102,7 @@ class AuthIT extends TestConfig {
                         .header(
                                 "Authorization",
                                 String.format("Bearer %s", EXPIRED_TOKEN)
-                        )
-                        .servletPath("/v2/auth/validate-token"))
+                        ))
                 .andExpect(status().isUnauthorized())
                 .andReturn()
                 .getResolvedException()

--- a/backend/src/test/java/com/michaelyi/post/PostIT.java
+++ b/backend/src/test/java/com/michaelyi/post/PostIT.java
@@ -60,7 +60,7 @@ class PostIT extends TestConfig {
 
     @Test
     void postConstructor() throws Exception {
-        String token = mvc.perform(post("/v1/auth/login")
+        String token = mvc.perform(post("/v2/auth/login")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(writer.writeValueAsString(
                                 new LoginRequest(AUTHORIZED_PASSWORD))
@@ -71,7 +71,7 @@ class PostIT extends TestConfig {
                 .getContentAsString();
 
         String text = "";
-        String error = mvc.perform(multipart("/v1/post")
+        String error = mvc.perform(multipart("/v2/post")
                         .file(new MockMultipartFile(
                                 "image",
                                 "Hello World!".getBytes()
@@ -88,7 +88,7 @@ class PostIT extends TestConfig {
         assertEquals("Fields cannot be blank.", error);
 
         text = "no-title";
-        error = mvc.perform(multipart("/v1/post")
+        error = mvc.perform(multipart("/v2/post")
                         .file(new MockMultipartFile(
                                 "image",
                                 "Hello World!".getBytes()
@@ -105,7 +105,7 @@ class PostIT extends TestConfig {
         assertEquals("Title cannot be blank.", error);
 
         text = "<h1></h1>";
-        error = mvc.perform(multipart("/v1/post")
+        error = mvc.perform(multipart("/v2/post")
                         .file(new MockMultipartFile(
                                 "image",
                                 "Hello World!".getBytes()
@@ -122,7 +122,7 @@ class PostIT extends TestConfig {
         assertEquals("Title cannot be blank.", error);
 
         text = "<h1>no-content</h1>";
-        error = mvc.perform(multipart("/v1/post")
+        error = mvc.perform(multipart("/v2/post")
                         .file(new MockMultipartFile(
                                 "image",
                                 "Hello World!".getBytes()
@@ -139,7 +139,7 @@ class PostIT extends TestConfig {
         assertEquals("Content cannot be blank.", error);
 
         text = "<h1>Oldboy (2003)</h1><p>content</p>";
-        String id = mvc.perform(multipart("/v1/post")
+        String id = mvc.perform(multipart("/v2/post")
                         .file(new MockMultipartFile(
                                 "image",
                                 "Hello World!".getBytes()
@@ -153,7 +153,7 @@ class PostIT extends TestConfig {
                 .andReturn()
                 .getResponse()
                 .getContentAsString();
-        String res = mvc.perform(get("/v1/post/" + id))
+        String res = mvc.perform(get("/v2/post/" + id))
                 .andExpect(status().isOk())
                 .andReturn()
                 .getResponse()
@@ -166,7 +166,7 @@ class PostIT extends TestConfig {
 
     @Test
     void createPost() throws Exception {
-        String token = mvc.perform(post("/v1/auth/login")
+        String token = mvc.perform(post("/v2/auth/login")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(writer.writeValueAsString(
                                 new LoginRequest(AUTHORIZED_PASSWORD))
@@ -178,7 +178,7 @@ class PostIT extends TestConfig {
 
         String text = "<h1>Already Exists (1994)</h1>content";
 
-        mvc.perform(multipart("/v1/post")
+        mvc.perform(multipart("/v2/post")
                         .file(new MockMultipartFile(
                                 "image",
                                 "Hello World!".getBytes()
@@ -190,7 +190,7 @@ class PostIT extends TestConfig {
                         ))
                 .andExpect(status().isCreated());
 
-        String error = mvc.perform(multipart("/v1/post")
+        String error = mvc.perform(multipart("/v2/post")
                         .file(new MockMultipartFile(
                                 "image",
                                 "Hello World!".getBytes()
@@ -207,7 +207,7 @@ class PostIT extends TestConfig {
 
         assertEquals(error, "A post with the same title already exists.");
 
-        mvc.perform(multipart("/v1/post")
+        mvc.perform(multipart("/v2/post")
                         .file(new MockMultipartFile(
                                 "image",
                                 "Hello World!".getBytes()
@@ -217,7 +217,7 @@ class PostIT extends TestConfig {
 
         text = "<h1>Title (1994)</h1>Content";
 
-        String id = mvc.perform(multipart("/v1/post")
+        String id = mvc.perform(multipart("/v2/post")
                         .file(new MockMultipartFile(
                                 "image",
                                 "Hello World!".getBytes()
@@ -232,7 +232,7 @@ class PostIT extends TestConfig {
                 .getResponse()
                 .getContentAsString();
 
-        String res = mvc.perform(get("/v1/post/" + id))
+        String res = mvc.perform(get("/v2/post/" + id))
                 .andExpect(status().isOk())
                 .andReturn()
                 .getResponse()
@@ -244,7 +244,7 @@ class PostIT extends TestConfig {
         assertEquals("Title (1994)", actual.getTitle());
         assertEquals("Content", actual.getContent());
 
-        byte[] imageRes = mvc.perform(get("/v1/post/image/" + id)
+        byte[] imageRes = mvc.perform(get("/v2/post/image/" + id)
                         .accept(MediaType.IMAGE_JPEG_VALUE))
                 .andExpect(status().isOk())
                 .andReturn()
@@ -256,7 +256,7 @@ class PostIT extends TestConfig {
 
     @Test
     void readPost() throws Exception {
-        String token = mvc.perform(post("/v1/auth/login")
+        String token = mvc.perform(post("/v2/auth/login")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(writer.writeValueAsString(
                                 new LoginRequest(AUTHORIZED_PASSWORD))
@@ -266,7 +266,7 @@ class PostIT extends TestConfig {
                 .getResponse()
                 .getContentAsString();
 
-        String error = mvc.perform(get("/v1/post/oldboy"))
+        String error = mvc.perform(get("/v2/post/oldboy"))
                 .andExpect(status().isNotFound())
                 .andReturn()
                 .getResolvedException()
@@ -276,7 +276,7 @@ class PostIT extends TestConfig {
         String text =
                 "<h1>Oldboy (2003)</h1><p>In Park Chan-wook's film...</p>";
 
-        String id = mvc.perform(multipart("/v1/post")
+        String id = mvc.perform(multipart("/v2/post")
                         .file(new MockMultipartFile(
                                 "image",
                                 "Hello World!".getBytes()
@@ -291,7 +291,7 @@ class PostIT extends TestConfig {
                 .getResponse()
                 .getContentAsString();
 
-        String res = mvc.perform(get("/v1/post/" + id))
+        String res = mvc.perform(get("/v2/post/" + id))
                 .andExpect(status().isOk())
                 .andReturn()
                 .getResponse()
@@ -309,7 +309,7 @@ class PostIT extends TestConfig {
 
     @Test
     void readPostImage() throws Exception {
-        String token = mvc.perform(post("/v1/auth/login")
+        String token = mvc.perform(post("/v2/auth/login")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(writer.writeValueAsString(
                                 new LoginRequest(AUTHORIZED_PASSWORD))
@@ -319,7 +319,7 @@ class PostIT extends TestConfig {
                 .getResponse()
                 .getContentAsString();
 
-        String error = mvc.perform(get("/v1/post/image/oldboy"))
+        String error = mvc.perform(get("/v2/post/image/oldboy"))
                 .andExpect(status().isNotFound())
                 .andReturn()
                 .getResolvedException()
@@ -329,7 +329,7 @@ class PostIT extends TestConfig {
         String text =
                 "<h1>Oldboy (2003)</h1><p>In Park Chan-wook's film...</p>";
 
-        String id = mvc.perform(multipart("/v1/post")
+        String id = mvc.perform(multipart("/v2/post")
                         .file(new MockMultipartFile(
                                 "image",
                                 "Hello World!".getBytes()
@@ -344,7 +344,7 @@ class PostIT extends TestConfig {
                 .getResponse()
                 .getContentAsString();
 
-        byte[] image = mvc.perform(get("/v1/post/image/" + id))
+        byte[] image = mvc.perform(get("/v2/post/image/" + id))
                 .andExpect(status().isOk())
                 .andReturn()
                 .getResponse()
@@ -354,7 +354,7 @@ class PostIT extends TestConfig {
 
     @Test
     void readAllPosts() throws Exception {
-        String token = mvc.perform(post("/v1/auth/login")
+        String token = mvc.perform(post("/v2/auth/login")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(writer.writeValueAsString(
                                 new LoginRequest(AUTHORIZED_PASSWORD))
@@ -365,7 +365,7 @@ class PostIT extends TestConfig {
                 .getContentAsString();
 
         String text = "<h1>Title (1994)</h1>Content";
-        mvc.perform(multipart("/v1/post")
+        mvc.perform(multipart("/v2/post")
                         .file(new MockMultipartFile(
                                 "image",
                                 "Hello World!".getBytes()
@@ -381,7 +381,7 @@ class PostIT extends TestConfig {
                 .getContentAsString();
 
         text = "<h1>Oldboy (2003)</h1><p>In Park Chan-wook's film...</p>";
-        mvc.perform(multipart("/v1/post")
+        mvc.perform(multipart("/v2/post")
                         .file(new MockMultipartFile(
                                 "image",
                                 "Hello World!".getBytes()
@@ -397,7 +397,7 @@ class PostIT extends TestConfig {
                 .getContentAsString();
 
         text = "<h1>It's A Wonderful Life (1946)</h1><p>by Frank Capra.</p>";
-        mvc.perform(multipart("/v1/post")
+        mvc.perform(multipart("/v2/post")
                         .file(new MockMultipartFile(
                                 "image",
                                 "Hello World!".getBytes()
@@ -412,7 +412,7 @@ class PostIT extends TestConfig {
                 .getResponse()
                 .getContentAsString();
 
-        String res = mvc.perform(get("/v1/post"))
+        String res = mvc.perform(get("/v2/post"))
                 .andExpect(status().isOk())
                 .andReturn()
                 .getResponse()
@@ -450,7 +450,7 @@ class PostIT extends TestConfig {
 
     @Test
     void updatePost() throws Exception {
-        String token = mvc.perform(post("/v1/auth/login")
+        String token = mvc.perform(post("/v2/auth/login")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(writer.writeValueAsString(
                                 new LoginRequest(AUTHORIZED_PASSWORD))
@@ -461,7 +461,7 @@ class PostIT extends TestConfig {
                 .getContentAsString();
 
         String text = "<h1>Oldboy (2003)</h1><p>by Park Chan-wook.</p>";
-        mvc.perform(multipart(HttpMethod.PUT, "/v1/post/oldboy")
+        mvc.perform(multipart(HttpMethod.PUT, "/v2/post/oldboy")
                         .file(new MockMultipartFile(
                                 "image",
                                 "Hello World!".getBytes()
@@ -469,7 +469,7 @@ class PostIT extends TestConfig {
                         .param("text", text))
                 .andExpect(status().isForbidden());
 
-        String error = mvc.perform(multipart(HttpMethod.PUT, "/v1/post/oldboy")
+        String error = mvc.perform(multipart(HttpMethod.PUT, "/v2/post/oldboy")
                         .file(new MockMultipartFile(
                                 "image",
                                 "Hello World!".getBytes()
@@ -488,7 +488,7 @@ class PostIT extends TestConfig {
 
         text = "<h1>Oldboy (2003)</h1><p>In Park Chan-wook's film...</p>";
 
-        String id = mvc.perform(multipart("/v1/post")
+        String id = mvc.perform(multipart("/v2/post")
                         .file(new MockMultipartFile(
                                 "image",
                                 "Hello World!".getBytes()
@@ -507,7 +507,7 @@ class PostIT extends TestConfig {
 
         String res = mvc.perform(multipart(
                         HttpMethod.PUT,
-                        String.format("/v1/post/%s", id))
+                        String.format("/v2/post/%s", id))
                         .file(new MockMultipartFile(
                                 "image",
                                 "Hello World!".getBytes()
@@ -528,7 +528,7 @@ class PostIT extends TestConfig {
         assertEquals("Oldboy (2004)", actual.getTitle());
         assertEquals("<p>by Park Chan-wook.</p>", actual.getContent());
 
-        res = mvc.perform(get("/v1/post/" + id))
+        res = mvc.perform(get("/v2/post/" + id))
                 .andExpect(status().isOk())
                 .andReturn()
                 .getResponse()
@@ -539,7 +539,7 @@ class PostIT extends TestConfig {
         assertEquals("Oldboy (2004)", actual.getTitle());
         assertEquals("<p>by Park Chan-wook.</p>", actual.getContent());
 
-        byte[] imageRes = mvc.perform(get("/v1/post/image/" + id)
+        byte[] imageRes = mvc.perform(get("/v2/post/image/" + id)
                         .accept(MediaType.IMAGE_JPEG_VALUE))
                 .andExpect(status().isOk())
                 .andReturn()
@@ -548,7 +548,7 @@ class PostIT extends TestConfig {
 
         assertArrayEquals("Hello World!".getBytes(), imageRes);
 
-        mvc.perform(multipart(HttpMethod.PUT, "/v1/post/oldboy")
+        mvc.perform(multipart(HttpMethod.PUT, "/v2/post/oldboy")
                         .file(new MockMultipartFile(
                                 "image",
                                 "New Hello World!".getBytes()
@@ -564,7 +564,7 @@ class PostIT extends TestConfig {
                 .getContentAsString();
 
         byte[] newImageRes = mvc.perform(get(String.format(
-                        "/v1/post/image/%s",
+                        "/v2/post/image/%s",
                         id
                 ))
                         .accept(MediaType.IMAGE_JPEG_VALUE))
@@ -579,7 +579,7 @@ class PostIT extends TestConfig {
 
     @Test
     void deletePost() throws Exception {
-        String token = mvc.perform(post("/v1/auth/login")
+        String token = mvc.perform(post("/v2/auth/login")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(writer.writeValueAsString(
                                 new LoginRequest(AUTHORIZED_PASSWORD)
@@ -591,10 +591,10 @@ class PostIT extends TestConfig {
 
         String text = "<h1>Oldboy (2003)</h1><p>by Park Chan-wook.</p>";
 
-        mvc.perform(delete("/v1/post/oldboy"))
+        mvc.perform(delete("/v2/post/oldboy"))
                 .andExpect(status().isForbidden());
 
-        String error = mvc.perform(delete("/v1/post/oldboy")
+        String error = mvc.perform(delete("/v2/post/oldboy")
                         .header(
                                 "Authorization",
                                 String.format("Bearer %s", token)
@@ -606,7 +606,7 @@ class PostIT extends TestConfig {
 
         assertEquals("Post not found.", error);
 
-        String id = mvc.perform(multipart("/v1/post")
+        String id = mvc.perform(multipart("/v2/post")
                         .file(
                                 new MockMultipartFile(
                                         "image",
@@ -623,7 +623,7 @@ class PostIT extends TestConfig {
                 .getResponse()
                 .getContentAsString();
 
-        String res = mvc.perform(get("/v1/post/" + id))
+        String res = mvc.perform(get("/v2/post/" + id))
                 .andExpect(status().isOk())
                 .andReturn()
                 .getResponse()
@@ -634,14 +634,14 @@ class PostIT extends TestConfig {
         assertEquals("Oldboy (2003)", actual.getTitle());
         assertEquals("<p>by Park Chan-wook.</p>", actual.getContent());
 
-        mvc.perform(delete("/v1/post/" + id)
+        mvc.perform(delete("/v2/post/" + id)
                         .header(
                                 "Authorization",
                                 String.format("Bearer %s", token)
                         ))
                 .andExpect(status().isOk());
 
-        error = mvc.perform(get("/v1/post/" + id))
+        error = mvc.perform(get("/v2/post/" + id))
                 .andExpect(status().isNotFound())
                 .andReturn()
                 .getResolvedException()


### PR DESCRIPTION
## Summary

Fixed the wrong api version prefix for context path being whitelisted in Spring Security, resulting in 403 for all endpoints.

## Changelog

- Added `CONTEXT_PATH` in security whitelisted endpoints

## Testing

- Tested locally