### PR TITLE
feat(security): added exception handling to security filter chain [PW-315]

### DIFF
--- a/backend/java/src/main/java/com/michaelyi/personalwebsite/auth/AuthEntryPoint.java
+++ b/backend/java/src/main/java/com/michaelyi/personalwebsite/auth/AuthEntryPoint.java
@@ -1,0 +1,25 @@
+package com.michaelyi.personalwebsite.auth;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class AuthEntryPoint implements AuthenticationEntryPoint {
+    @Override
+    public void commence(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            AuthenticationException authException
+    ) throws IOException, ServletException {
+        response.sendError(
+                HttpServletResponse.SC_UNAUTHORIZED,
+                "Unauthorized"
+        );
+    }
+}

--- a/backend/java/src/test/java/com/michaelyi/personalwebsite/post/PostIT.java
+++ b/backend/java/src/test/java/com/michaelyi/personalwebsite/post/PostIT.java
@@ -213,7 +213,7 @@ class PostIT extends IntegrationTest {
                                 "Hello World!".getBytes()
                         ))
                         .param("text", text))
-                .andExpect(status().isForbidden());
+                .andExpect(status().isUnauthorized());
 
         text = "<h1>Title (1994)</h1>Content";
 
@@ -467,7 +467,7 @@ class PostIT extends IntegrationTest {
                                 "Hello World!".getBytes()
                         ))
                         .param("text", text))
-                .andExpect(status().isForbidden());
+                .andExpect(status().isUnauthorized());
 
         String error = mvc.perform(multipart(HttpMethod.PUT, "/v2/post/oldboy")
                         .file(new MockMultipartFile(
@@ -592,7 +592,7 @@ class PostIT extends IntegrationTest {
         String text = "<h1>Oldboy (2003)</h1><p>by Park Chan-wook.</p>";
 
         mvc.perform(delete("/v2/post/oldboy"))
-                .andExpect(status().isForbidden());
+                .andExpect(status().isUnauthorized());
 
         String error = mvc.perform(delete("/v2/post/oldboy")
                         .header(


### PR DESCRIPTION
## Summary

Added exception handling to SecurityFilterChain

## Changelog

- Implemented an `AuthenticationEntryPoint` for returning 401 on all unauthorized requests
- Added exception handling to SecurityFilterChain

## Testing

- Tested locally
- Updated test suites accordingly