### PR TITLE
feat(validate-token): changed http method to post for token validation [PW-335]

### DIFF
--- a/backend/java/src/main/java/com/michaelyi/personalwebsite/auth/AuthController.java
+++ b/backend/java/src/main/java/com/michaelyi/personalwebsite/auth/AuthController.java
@@ -2,7 +2,6 @@ package com.michaelyi.personalwebsite.auth;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -47,7 +46,7 @@ public class AuthController {
         return new ResponseEntity<>(res, res.getHttpStatus());
     }
 
-    @GetMapping("/validate-token")
+    @PostMapping("/validate-token")
     public ResponseEntity<HttpResponse> validateToken(
             @RequestHeader("Authorization") String authHeader) {
         HttpResponse res = new HttpResponse();

--- a/backend/java/src/test/java/com/michaelyi/personalwebsite/auth/AuthIT.java
+++ b/backend/java/src/test/java/com/michaelyi/personalwebsite/auth/AuthIT.java
@@ -2,7 +2,6 @@ package com.michaelyi.personalwebsite.auth;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -58,7 +57,7 @@ class AuthIT extends IntegrationTest {
         String unauthorizedToken = AuthTestUtil.generateToken(
                 AuthUtil.JWT_EXPIRATION);
 
-        String res = mvc.perform(get("/v2/auth/validate-token")
+        String res = mvc.perform(post("/v2/auth/validate-token")
                 .header(
                         "Authorization",
                         String.format("Bearer %s", unauthorizedToken))
@@ -73,7 +72,7 @@ class AuthIT extends IntegrationTest {
 
         String expiredToken = AuthTestUtil.generateToken(
                 AuthUtil.JWT_EXPIRATION * -1);
-        res = mvc.perform(get("/v2/auth/validate-token")
+        res = mvc.perform(post("/v2/auth/validate-token")
                 .header(
                         "Authorization",
                         String.format("Bearer %s", expiredToken))
@@ -100,7 +99,7 @@ class AuthIT extends IntegrationTest {
                 LoginResponse.class);
         String token = loginResponse.getToken();
 
-        mvc.perform(get("/v2/auth/validate-token")
+        mvc.perform(post("/v2/auth/validate-token")
                 .header("Authorization",
                         String.format("Bearer %s", token)))
                 .andExpect(status().isNoContent());

--- a/frontend/admin/src/services/auth.js
+++ b/frontend/admin/src/services/auth.js
@@ -19,6 +19,7 @@ export async function validateToken() {
     const res = await fetch(
         `${process.env.REACT_APP_API_URL}/auth/validate-token`,
         {
+            method: "POST",
             headers: {
                 Authorization: `Bearer ${localStorage.getItem("token")}`,
             },


### PR DESCRIPTION
## Summary

Changed HTTP method for `/v2/auth/validate-token` endpoint.

## Changelog

- Changed method from `GET` to `POST` for `/v2/auth/validate-token`

## Testing

- Updated integration tests with new method header