### PR TITLE
feat(controller): moved rest controller logic out of service layer [PW-339]

### DIFF
--- a/backend/java/src/main/java/com/michaelyi/personalwebsite/auth/AuthFilter.java
+++ b/backend/java/src/main/java/com/michaelyi/personalwebsite/auth/AuthFilter.java
@@ -35,17 +35,19 @@ public class AuthFilter extends OncePerRequestFilter {
             return;
         }
 
-        String authHeader = request.getHeader("Authorization");
-
-        if (AuthUtil.isAuthHeaderInvalid(authHeader)) {
-            filterChain.doFilter(request, response);
-            return;
-        }
-
         if (SecurityContextHolder
                 .getContext()
                 .getAuthentication() == null) {
-            authService.validateToken(authHeader);
+
+            String authHeader = request.getHeader("Authorization");
+
+            if (AuthUtil.isAuthHeaderInvalid(authHeader)) {
+                filterChain.doFilter(request, response);
+                return;
+            }
+
+            String token = authHeader.substring(AuthUtil.BEARER_PREFIX_LENGTH);
+            authService.validateToken(token);
 
             UsernamePasswordAuthenticationToken authToken = new UsernamePasswordAuthenticationToken(
                     adminUser,

--- a/backend/java/src/main/java/com/michaelyi/personalwebsite/auth/AuthUtil.java
+++ b/backend/java/src/main/java/com/michaelyi/personalwebsite/auth/AuthUtil.java
@@ -9,6 +9,7 @@ import io.jsonwebtoken.security.Keys;
 
 public class AuthUtil {
     public static final String ADMIN_EMAIL = "admin@michael-yi.com";
+    public static final int BEARER_PREFIX_LENGTH = 7;
     public static final long JWT_EXPIRATION = 1000 * 60 * 60 * 24 * 7;
 
     public static boolean isAuthHeaderInvalid(String authHeader) {

--- a/backend/java/src/test/java/com/michaelyi/personalwebsite/auth/AuthIT.java
+++ b/backend/java/src/test/java/com/michaelyi/personalwebsite/auth/AuthIT.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.TestPropertySource;
@@ -59,7 +60,7 @@ class AuthIT extends IntegrationTest {
 
         String res = mvc.perform(post("/v2/auth/validate-token")
                 .header(
-                        "Authorization",
+                        HttpHeaders.AUTHORIZATION,
                         String.format("Bearer %s", unauthorizedToken))
                 .servletPath("/v2/auth/validate-token"))
                 .andExpect(status().isUnauthorized())


### PR DESCRIPTION
## Summary

Moved REST controller logic out of service layer.

## Changelog

- Updated `login` method of `AuthService` to not include `AuthRequest` as a param
- Updated `validateToken` method of `AuthService` to not include the Authorization header within the params
- Moved Authorization header validation logic to controller layer when validating tokens

## Testing

- Updated all tests according to changes above