### PR TITLE
feat(dao): removed flush methods from dao layers [PW-340]

### DIFF
--- a/backend/java/src/main/java/com/michaelyi/personalwebsite/cache/CacheDao.java
+++ b/backend/java/src/main/java/com/michaelyi/personalwebsite/cache/CacheDao.java
@@ -24,12 +24,4 @@ public class CacheDao {
     public void delete(String key) {
         template.delete(key);
     }
-
-    public void flushAll() {
-        template
-                .getConnectionFactory()
-                .getConnection()
-                .serverCommands()
-                .flushAll();
-    }
 }

--- a/backend/java/src/main/java/com/michaelyi/personalwebsite/post/PostDao.java
+++ b/backend/java/src/main/java/com/michaelyi/personalwebsite/post/PostDao.java
@@ -46,9 +46,4 @@ public class PostDao {
         String sql = "DELETE FROM post WHERE id = ?";
         template.update(sql, id);
     }
-
-    public void deleteAllPosts() {
-        String sql = "DELETE FROM post";
-        template.update(sql);
-    }
 }


### PR DESCRIPTION
## Summary

Removed any methods relating to flushing SQL tables or Redis keys in DAO layers.

## Changelog

- Removed `flushAll` method from `CacheDao.java`
- Removed `deleteAllPosts` method from `PostDao.java`

## Testing

- Manually flushed data after each integration test